### PR TITLE
fix selector

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -46,7 +46,7 @@ function toggleFiles() {
 
 function addToggleBtn() {
 	const toggleBtn = createHtml(`<a class="hide-files-btn btn btn-sm">${label()}</a>`);
-	const btnContainer = document.querySelector('.file-navigation .right .btn-group');
+	const btnContainer = document.querySelector('.file-navigation .btn-group.right');
 
 	fixupOtherButtons();
 


### PR DESCRIPTION
Within the last day or so the file navigation was changed, making the toggle button not show up anymore, this fixes that.

Before:
![before](https://i.imgur.com/eJLYi0o.png)
After:
![after](https://i.imgur.com/9nEmNla.png)

@sindresorhus