### PR TITLE
remove toggle btn in dimmed mode. closes #35

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -86,7 +86,9 @@ function label() {
 }
 
 function trigger() {
-	addToggleBtn();
+	if (visibility === 'hidden') {
+		addToggleBtn();
+	}
 	toggleFiles();
 }
 
@@ -120,3 +122,4 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	});
 });
+


### PR DESCRIPTION
Only render the toggle button when in `dimmed` mode.