### PR TITLE
Let file selectors match `<span>` as well as `<a>`

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -26,8 +26,8 @@ function toggleFiles() {
 	let i = 0;
 
 	for (const el of rows) {
-		if (el.querySelector('.content > * > *')) {
-			const fileName = el.querySelector('td.content > * > *').innerText;
+		if (el.querySelector('.content > span > :-webkit-any(a, span)')) {
+			const fileName = el.querySelector('td.content > span > :-webkit-any(a, span)').innerText;
 
 			if (hideRegExp && hideRegExp.test(fileName)) {
 				el.classList.add('dimmed');
@@ -50,7 +50,7 @@ function reorderFiles() {
 	const normal = document.createDocumentFragment();
 
 	for (const el of rows) {
-		const filename = el.querySelector('.content > * > *').innerText;
+		const filename = el.querySelector('.content > span > :-webkit-any(a, span)').innerText;
 
 		if (hideRegExp && hideRegExp.test(filename)) {
 			dotted.appendChild(el);

--- a/extension/content.js
+++ b/extension/content.js
@@ -26,8 +26,8 @@ function toggleFiles() {
 	let i = 0;
 
 	for (const el of rows) {
-		if (el.querySelector('.content a')) {
-			const fileName = el.querySelector('td.content a').innerText;
+		if (el.querySelector('.content > * > *')) {
+			const fileName = el.querySelector('td.content > * > *').innerText;
 
 			if (hideRegExp && hideRegExp.test(fileName)) {
 				el.classList.add('dimmed');
@@ -50,7 +50,7 @@ function reorderFiles() {
 	const normal = document.createDocumentFragment();
 
 	for (const el of rows) {
-		const filename = el.querySelector('.content a').innerText;
+		const filename = el.querySelector('.content > * > *').innerText;
 
 		if (hideRegExp && hideRegExp.test(filename)) {
 			dotted.appendChild(el);

--- a/extension/content.js
+++ b/extension/content.js
@@ -34,7 +34,7 @@ function toggleFiles() {
 				el.style.display = toggleOn ? 'none' : 'table-row';
 			}
 		} else if (++i === 1) {
-			// remove top border
+			// Remove top border
 			el.classList.add('first');
 		}
 	}
@@ -85,7 +85,7 @@ function addToggleBtn() {
 	}
 
 	if (fileTable && inRootView()) {
-		// insert at the end of the table
+		// Insert at the end of the table
 		fileTable.insertBefore(toggleBtn, fileTable.children[0]);
 		addToggleBtnEvents();
 	}


### PR DESCRIPTION
This fixes the behavior at https://github.com/EFForg/https-everywhere/tree/24338b1e7a3d136023bb91600be9587e1ba55f97

Fixes https://github.com/sindresorhus/hide-files-on-github/issues/43