### PR TITLE
Add hide-files-from-bitbucket-pr to Related section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Install it from the [Chrome Web Store](https://chrome.google.com/webstore/detail
 
 ## Related
 
-- [Hide Files from Bitbucket PR](https://github.com/Zhouzi/hide-files-from-bitbucket-pr) - Hides non-essential files in Bitbucket's pull request viewer
+- [Hide Files from Bitbucket PR](https://github.com/Zhouzi/hide-files-from-bitbucket-pr) - Hides nonessential files in Bitbucket's pull request viewer
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,11 @@ In the options, you can choose what files/directories to hide with a custom rege
 Install it from the [Chrome Web Store](https://chrome.google.com/webstore/detail/hide-files-on-github/lpnakhpaodhdkleejaehlapdhbgjbddp) or [manually](http://superuser.com/a/247654/6877).
 
 
+## Related
+
+- [Hide Files from Bitbucket PR](https://github.com/Zhouzi/hide-files-from-bitbucket-pr) - Hides non-essential files in Bitbucket's pull request viewer
+
+
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)


### PR DESCRIPTION
As discussed in #47, this PR adds a "related" section to the readme with a similar Bitbucket extension.