### PR TITLE
Support pjax updates

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -100,10 +100,12 @@ async function init() {
 
 	update(settings);
 	document.addEventListener('pjax:end', () => update(settings));
-	const ajaxFiles = select('include-fragment.file-wrap').parentNode;
-	new MutationObserver(() => update(settings)).observe(ajaxFiles, {
-		childList: true
-	});
+	const ajaxFiles = select('include-fragment.file-wrap');
+	if (ajaxFiles) {
+		new MutationObserver(() => update(settings)).observe(ajaxFiles.parentNode, {
+			childList: true
+		});
+	}
 }
 
 if (document.readyState === 'loading') {

--- a/extension/content.js
+++ b/extension/content.js
@@ -108,15 +108,21 @@ function addToggleBtn(filesPreview) {
 }
 
 function init() {
+	// Update on fragment update
+	const observer = new MutationObserver(update);
+	const observeFragment = () => {
+		const ajaxFiles = select('include-fragment.file-wrap');
+		if (ajaxFiles) {
+			observer.observe(ajaxFiles.parentNode, {
+				childList: true
+			});
+		}
+	};
 
 	update();
+	observeFragment();
 	document.addEventListener('pjax:end', update); // Update on page change
-	const ajaxFiles = select('include-fragment.file-wrap');
-	if (ajaxFiles) {
-		new MutationObserver(() => update(settings)).observe(ajaxFiles.parentNode, {
-			childList: true
-		});
-	}
+	document.addEventListener('pjax:end', observeFragment);
 }
 
 Promise.all([domLoaded, settingsPromise]).then(init);

--- a/extension/content.js
+++ b/extension/content.js
@@ -11,6 +11,14 @@ const settingsPromise = HideFilesOnGitHub.storage.get().then(retrieved => {
 	settings.hideRegExp = new RegExp(settings.hideRegExp.replace(/\n+/g, '|'), 'i');
 });
 
+const domLoaded = new Promise(resolve => {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', resolve);
+	} else {
+		resolve();
+	}
+});
+
 function overflowsParent(el) {
 	return el.getBoundingClientRect().right > el.parentNode.getBoundingClientRect().right;
 }
@@ -99,8 +107,7 @@ function addToggleBtn(filesPreview) {
 	}
 }
 
-async function init() {
-	await settingsPromise;
+function init() {
 
 	update();
 	document.addEventListener('pjax:end', update); // Update on page change
@@ -112,8 +119,4 @@ async function init() {
 	}
 }
 
-if (document.readyState === 'loading') {
-	document.addEventListener('DOMContentLoaded', init);
-} else {
-	init();
-}
+Promise.all([domLoaded, settingsPromise]).then(init);

--- a/extension/content.js
+++ b/extension/content.js
@@ -100,6 +100,10 @@ async function init() {
 
 	update(settings);
 	document.addEventListener('pjax:end', () => update(settings));
+	const ajaxFiles = select('include-fragment.file-wrap').parentNode;
+	new MutationObserver(() => update(settings)).observe(ajaxFiles, {
+		childList: true
+	});
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
I think this happens when GitHub serves an outdated HTML files and then fetches the recent content. Perhaps when you visit a repo that has changed since your last visit.

Here you can see me visiting such a repo:

![before](https://user-images.githubusercontent.com/1402241/28703023-a3d0137e-7393-11e7-80be-7d6b85310702.gif)

And here's after this PR:

![after](https://user-images.githubusercontent.com/1402241/28703037-c1373884-7393-11e7-8630-0f996ad0ef6a.gif)

The good thing is that if you find a repo with this behavior, it's easy to test: you can go back and forth in history and it will always behave the same, allowing you to reload this extension between tries.