### PR TITLE
Firefox support

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -25,7 +25,7 @@ function overflowsParent(el) {
 
 function update() {
 	let {filesPreview, hideRegExp} = settings;
-	const files = select.all('.files .js-navigation-item .content > span > :-webkit-any(a, span)');
+	const files = select.all('.files .js-navigation-item .content > span > *');
 	const hidden = document.createDocumentFragment();
 	if (filesPreview) {
 		filesPreview = document.createElement('span');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,12 @@
 	"homepage_url": "https://github.com/sindresorhus/hide-files-on-github",
 	"manifest_version": 2,
 	"minimum_chrome_version": "51",
+	"applications": {
+		"gecko": {
+			"id": "{e3ad1b0f-99ff-4df7-87bb-0b17cfa9628d}",
+			"strict_min_version": "53.0"
+		}
+	},
 	"icons": {
 		"128": "icon.png"
 	},


### PR DESCRIPTION
Saw #54 and still making a PR to support Firefox since the changes are minor. 

- Dropped `:-webkit-any(a, span)` selector which was introduced with https://github.com/sindresorhus/hide-files-on-github/commit/298ab686f73c3b0d49e96ced23af770552ea58a7 and had incompatibility with Firefox. Firefox only supports `:-moz-any()` and [not the newer `:matches()`][1]  pseudo-class.
- ~~Firefox supports `chrome` namespace and it was used for storage~~
- ~~Storage changed from `sync` to `local` (`sync` wasn't working with testing, Anyway to fix this ?)~~

[1]: https://caniuse.com/#feat=css-matches-pseudo

Changes tested with Firefox 62 and Chromium 68. 

If maintainers don't want to support Firefox because of maintenance burden, I would be happy to Firefox support here or submit it as separate extension on AMO under different name. Really  wish this would be accepted here because separate extension will most likely lead to code syncing and update issues.  