### PR TITLE
Update package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13728,9 +13728,9 @@
 			}
 		},
 		"webext-dynamic-content-scripts": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.2.tgz",
-			"integrity": "sha512-8X2yqLPjP8jLMdCMLz/QXVkipt9H9J1kitUoG8S9O03urQnsRvduXnkmfpTZnNajr0q2mn5DN6ReXMZOp87vUw==",
+			"version": "6.0.3-0",
+			"resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.3-0.tgz",
+			"integrity": "sha512-6qWp+SJtrnAFv2E1HyZW+3wYNPm/tbltjtds1zKpIp8cbEwMFjc7c4VepIJmMclZGuPm0AMVunIjgbCwwF7Psg==",
 			"requires": {
 				"@types/chrome": "0.0.86",
 				"content-scripts-register-polyfill": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,74 +54,47 @@
 			}
 		},
 		"@babel/polyfill": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
-			"integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+			"integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.5.7",
-				"regenerator-runtime": "^0.11.1"
-			}
-		},
-		"@babel/register": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
-			"integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.5.7",
-				"find-cache-dir": "^1.0.0",
-				"home-or-tmp": "^3.0.0",
-				"lodash": "^4.17.10",
-				"mkdirp": "^0.5.1",
-				"pirates": "^4.0.0",
-				"source-map-support": "^0.5.9"
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.2"
 			},
 			"dependencies": {
-				"find-cache-dir": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-					"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^1.0.0",
-						"pkg-dir": "^2.0.0"
-					}
-				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"pkg-dir": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"core-js": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
 					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.11",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-					"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
+				}
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+			"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+			"dev": true,
+			"requires": {
+				"regenerator-runtime": "^0.13.2"
+			}
+		},
+		"@babel/runtime-corejs2": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
+			"integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+					"dev": true
 				}
 			}
 		},
@@ -169,19 +142,107 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
 		},
-		"@sindresorhus/tsconfig": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-0.3.0.tgz",
-			"integrity": "sha512-dc6iqngaTOgnW6uZEj75FtIv1auLICDWRM8nrB8LJDjVFRS3FPa8okVhAgFoEC4c1orm0PLPQE0M+pJQo8Ag8Q==",
+		"@sindresorhus/is": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
 			"dev": true
 		},
+		"@sindresorhus/tsconfig": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-0.4.0.tgz",
+			"integrity": "sha512-5b9KULv6SGKZ/Ka7EzLxcqcnD9WuZ1wm/RwfVw4UHr+HoMP7FRpvBKbQ0TIeBOCeSyE5zzPTjYmRgfZnJ3Ifxw==",
+			"dev": true
+		},
+		"@snyk/composer-lockfile-parser": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@snyk/composer-lockfile-parser/-/composer-lockfile-parser-1.0.3.tgz",
+			"integrity": "sha512-hb+6E7kMzWlcwfe//ILDoktBPKL2a3+RnJT/CXnzRXaiLQpsdkf5li4q2v0fmvd+4v7L3tTN8KM+//lJyviEkg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
+		},
+		"@snyk/dep-graph": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.10.0.tgz",
+			"integrity": "sha512-QwQTmmnVb1mjAffGsjKKrwit8ahLWyhlKWQcTVZo9UXFgWAwiuCjTXKAXhijZjGvrXQzNf5KbIBu+SZ1Dq2toQ==",
+			"dev": true,
+			"requires": {
+				"graphlib": "^2.1.5",
+				"lodash": "^4.7.14",
+				"object-hash": "^1.3.1",
+				"semver": "^6.0.0",
+				"source-map-support": "^0.5.11",
+				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
+		"@snyk/gemfile": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
+			"integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==",
+			"dev": true
+		},
+		"@szmarczak/http-timer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
+			"requires": {
+				"defer-to-connect": "^1.0.1"
+			}
+		},
+		"@types/agent-base": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/agent-base/-/agent-base-4.2.0.tgz",
+			"integrity": "sha512-8mrhPstU+ZX0Ugya8tl5DsDZ1I5ZwQzbL/8PA0z8Gj0k9nql7nkaMzmPVLj+l/nixWaliXi+EBiLA8bptw3z7Q==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/chrome": {
-			"version": "0.0.81",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.81.tgz",
-			"integrity": "sha512-NKkQGMJSppFwUwMbEbYcq8/p/ACVHmQCUpWaqJVdHn81tU3by+YXnxw86KFa0tUSLamu35wtzFaMyY4TFaMceQ==",
+			"version": "0.0.86",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.86.tgz",
+			"integrity": "sha512-7ehebPf/5IR64SYdD2Vig0q0oUCNbWMQ29kASlNJaHVVtA5/J/DnrxnYVPCID70o7LgHdYsav6I4/XdqAxjTLQ==",
 			"requires": {
 				"@types/filesystem": "*"
 			}
+		},
+		"@types/debug": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.4.tgz",
+			"integrity": "sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==",
+			"dev": true
+		},
+		"@types/eslint-visitor-keys": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+			"dev": true
+		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/filesystem": {
 			"version": "0.0.29",
@@ -196,10 +257,22 @@
 			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
 			"integrity": "sha1-wFTor02d11205jq8dviFFocU1LM="
 		},
+		"@types/json-schema": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+			"integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+			"dev": true
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
 		"@types/node": {
-			"version": "11.11.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+			"version": "12.6.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+			"integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
 			"dev": true
 		},
 		"@types/prop-types": {
@@ -209,9 +282,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.8.15",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.15.tgz",
-			"integrity": "sha512-dMhzw1rWK+wwJWvPp5Pk12ksSrm/z/C/+lOQbMZ7YfDQYnJ02bc0wtg4EJD9qrFhuxFrf/ywNgwTboucobJqQg==",
+			"version": "16.8.24",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
+			"integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -219,32 +292,45 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz",
-			"integrity": "sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",
+			"integrity": "sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/parser": "1.5.0",
-				"@typescript-eslint/typescript-estree": "1.5.0",
-				"requireindex": "^1.2.0",
+				"@typescript-eslint/experimental-utils": "1.13.0",
+				"eslint-utils": "^1.3.1",
+				"functional-red-black-tree": "^1.0.1",
+				"regexpp": "^2.0.1",
 				"tsutils": "^3.7.0"
 			}
 		},
-		"@typescript-eslint/parser": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.5.0.tgz",
-			"integrity": "sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==",
+		"@typescript-eslint/experimental-utils": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+			"integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "1.5.0",
-				"eslint-scope": "^4.0.0",
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "1.13.0",
+				"eslint-scope": "^4.0.0"
+			}
+		},
+		"@typescript-eslint/parser": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+			"integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+			"dev": true,
+			"requires": {
+				"@types/eslint-visitor-keys": "^1.0.0",
+				"@typescript-eslint/experimental-utils": "1.13.0",
+				"@typescript-eslint/typescript-estree": "1.13.0",
 				"eslint-visitor-keys": "^1.0.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz",
-			"integrity": "sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+			"integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
 			"dev": true,
 			"requires": {
 				"lodash.unescape": "4.0.1",
@@ -475,16 +561,10 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
 			"integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
 		},
-		"acorn-dynamic-import": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-			"dev": true
-		},
 		"acorn-globals": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
-			"integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"requires": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
@@ -497,14 +577,14 @@
 			"dev": true
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
 		},
 		"adbkit": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/adbkit/-/adbkit-2.11.0.tgz",
-			"integrity": "sha512-j2vUhEeZmCiqBP+p77CpPWQTcT20rOmSmRHFUTZUwUpxzeCd3fXop4NAGYztSY9/FNU4bT/qqvYQ4EZKuCXhfA==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/adbkit/-/adbkit-2.11.1.tgz",
+			"integrity": "sha512-hDTiRg9NX3HQt7WoDAPCplUpvzr4ZzQa2lq7BdTTJ/iOZ6O7YNAs6UYD8sFAiBEcYHDRIyq3cm9sZP6uZnhvXw==",
 			"dev": true,
 			"requires": {
 				"adbkit-logcat": "^1.1.0",
@@ -516,6 +596,12 @@
 				"split": "~0.3.3"
 			},
 			"dependencies": {
+				"bluebird": {
+					"version": "2.9.34",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+					"integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
+					"dev": true
+				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -549,57 +635,60 @@
 			}
 		},
 		"addons-linter": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-1.4.1.tgz",
-			"integrity": "sha512-AX8nCD/gy/6DoX4B7vTMQV6pcP8tG0BjxB3Jv44VZrUTYG+ojHx26abRDyUn+fDqWGf8qzeVn0Vss/NMNjMouA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/addons-linter/-/addons-linter-1.10.0.tgz",
+			"integrity": "sha512-2i2qSayVPx4h1Aa2ZTdQlpgmjcCNIHZ4AJQS8V/QsBXIdmXl+Djmeyr096bjaC3Usq0rZfYhGgFdwR1dgHVItw==",
 			"dev": true,
 			"requires": {
-				"@babel/polyfill": "7.0.0",
-				"@babel/register": "7.0.0",
-				"ajv": "6.5.5",
+				"ajv": "6.10.0",
 				"ajv-merge-patch": "4.1.0",
-				"chalk": "2.4.0",
-				"cheerio": "1.0.0-rc.2",
+				"chalk": "2.4.2",
+				"cheerio": "1.0.0-rc.3",
 				"columnify": "1.5.4",
 				"common-tags": "1.8.0",
 				"crx-parser": "0.1.2",
-				"deepmerge": "2.2.1",
-				"dispensary": "0.27.0",
-				"es6-promisify": "5.0.0",
-				"eslint": "5.0.1",
+				"deepmerge": "3.2.0",
+				"dispensary": "0.37.0",
+				"es6-promisify": "6.0.1",
+				"eslint": "5.16.0",
 				"eslint-plugin-no-unsafe-innerhtml": "1.0.16",
 				"eslint-visitor-keys": "1.0.0",
-				"espree": "4.1.0",
-				"esprima": "3.1.3",
-				"first-chunk-stream": "2.0.0",
-				"fluent-syntax": "0.7.0",
-				"fsevents": "2.0.1",
-				"glob": "7.1.3",
+				"espree": "5.0.1",
+				"esprima": "4.0.1",
+				"first-chunk-stream": "3.0.0",
+				"fluent-syntax": "0.13.0",
+				"fsevents": "2.0.7",
+				"glob": "7.1.4",
 				"is-mergeable-object": "1.1.0",
 				"jed": "1.1.1",
-				"os-locale": "3.0.1",
-				"pino": "5.9.0",
+				"mdn-browser-compat-data": "0.0.82",
+				"os-locale": "3.1.0",
+				"pino": "5.12.6",
 				"po2json": "0.4.5",
-				"postcss": "7.0.6",
+				"postcss": "7.0.16",
 				"probe-image-size": "4.0.0",
-				"relaxed-json": "1.0.1",
-				"semver": "5.6.0",
-				"shelljs": "0.8.3",
-				"snyk": "1.110.2",
-				"source-map-support": "0.5.6",
-				"strip-bom-stream": "3.0.0",
+				"regenerator-runtime": "0.13.2",
+				"relaxed-json": "1.0.3",
+				"semver": "6.1.1",
+				"source-map-support": "0.5.12",
+				"strip-bom-stream": "4.0.0",
 				"tosource": "1.0.0",
-				"upath": "1.1.0",
+				"upath": "1.1.2",
 				"whatwg-url": "7.0.0",
-				"xmldom": "0.1.27",
-				"yargs": "12.0.2",
-				"yauzl": "2.9.2"
+				"yargs": "13.2.4",
+				"yauzl": "2.10.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"dev": true
+				},
 				"ajv": {
-					"version": "6.5.5",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-					"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^2.0.1",
@@ -608,10 +697,16 @@
 						"uri-js": "^4.2.2"
 					}
 				},
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -624,27 +719,21 @@
 					}
 				},
 				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"chalk": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
-					"integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
-				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-					"dev": true
 				},
 				"cli-cursor": {
 					"version": "2.1.0",
@@ -655,95 +744,129 @@
 						"restore-cursor": "^2.0.0"
 					}
 				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
 					}
 				},
-				"decamelize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 					"dev": true,
 					"requires": {
-						"xregexp": "4.0.0"
+						"esutils": "^2.0.2"
 					}
 				},
 				"eslint": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.0.1.tgz",
-					"integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
+					"version": "5.16.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.5.0",
-						"babel-code-frame": "^6.26.0",
+						"@babel/code-frame": "^7.0.0",
+						"ajv": "^6.9.1",
 						"chalk": "^2.1.0",
 						"cross-spawn": "^6.0.5",
-						"debug": "^3.1.0",
-						"doctrine": "^2.1.0",
-						"eslint-scope": "^4.0.0",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"eslint-scope": "^4.0.3",
+						"eslint-utils": "^1.3.1",
 						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^4.0.0",
+						"espree": "^5.0.1",
 						"esquery": "^1.0.1",
 						"esutils": "^2.0.2",
-						"file-entry-cache": "^2.0.0",
+						"file-entry-cache": "^5.0.1",
 						"functional-red-black-tree": "^1.0.1",
 						"glob": "^7.1.2",
-						"globals": "^11.5.0",
-						"ignore": "^3.3.3",
+						"globals": "^11.7.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
 						"imurmurhash": "^0.1.4",
-						"inquirer": "^5.2.0",
-						"is-resolvable": "^1.1.0",
-						"js-yaml": "^3.11.0",
+						"inquirer": "^6.2.2",
+						"js-yaml": "^3.13.0",
 						"json-stable-stringify-without-jsonify": "^1.0.1",
 						"levn": "^0.3.0",
-						"lodash": "^4.17.5",
+						"lodash": "^4.17.11",
 						"minimatch": "^3.0.4",
 						"mkdirp": "^0.5.1",
 						"natural-compare": "^1.4.0",
 						"optionator": "^0.8.2",
 						"path-is-inside": "^1.0.2",
-						"pluralize": "^7.0.0",
 						"progress": "^2.0.0",
-						"regexpp": "^1.1.0",
-						"require-uncached": "^1.0.3",
-						"semver": "^5.5.0",
-						"string.prototype.matchall": "^2.0.0",
+						"regexpp": "^2.0.1",
+						"semver": "^5.5.1",
 						"strip-ansi": "^4.0.0",
 						"strip-json-comments": "^2.0.1",
-						"table": "^4.0.3",
+						"table": "^5.2.3",
 						"text-table": "^0.2.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+							"dev": true
+						}
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
 					}
 				},
 				"espree": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-					"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 					"dev": true,
 					"requires": {
-						"acorn": "^6.0.2",
+						"acorn": "^6.0.7",
 						"acorn-jsx": "^5.0.0",
 						"eslint-visitor-keys": "^1.0.0"
 					}
 				},
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
-				},
 				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
+						"get-stream": "^4.0.0",
 						"is-stream": "^1.1.0",
 						"npm-run-path": "^2.0.0",
 						"p-finally": "^1.0.0",
@@ -751,15 +874,13 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 					"dev": true,
 					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
+						"flat-cache": "^2.0.1"
 					}
 				},
 				"find-up": {
@@ -771,31 +892,82 @@
 						"locate-path": "^3.0.0"
 					}
 				},
-				"ignore": {
-					"version": "3.3.10",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-					"dev": true
-				},
-				"inquirer": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-					"integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"inquirer": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^2.1.0",
+						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rxjs": "^5.5.2",
+						"rxjs": "^6.4.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
+						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.15",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+							"dev": true
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
 					}
 				},
 				"invert-kv": {
@@ -803,6 +975,16 @@
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
 				},
 				"lcid": {
 					"version": "2.0.0",
@@ -824,9 +1006,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -835,9 +1017,9 @@
 					},
 					"dependencies": {
 						"mimic-fn": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-							"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+							"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 							"dev": true
 						}
 					}
@@ -852,12 +1034,12 @@
 					}
 				},
 				"os-locale": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-					"integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 					"dev": true,
 					"requires": {
-						"execa": "^0.10.0",
+						"execa": "^1.0.0",
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
@@ -881,9 +1063,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"path-exists": {
@@ -892,10 +1074,16 @@
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
-				"regexpp": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-					"integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+				"regenerator-runtime": {
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+					"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 					"dev": true
 				},
 				"restore-cursor": {
@@ -909,26 +1097,28 @@
 					}
 				},
 				"rxjs": {
-					"version": "5.5.12",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-					"integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+					"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 					"dev": true,
 					"requires": {
-						"symbol-observable": "1.0.1"
+						"tslib": "^1.9.0"
 					}
 				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
 					"dev": true
 				},
 				"slice-ansi": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+					"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 					"dev": true,
 					"requires": {
+						"ansi-styles": "^3.2.0",
+						"astral-regex": "^1.0.0",
 						"is-fullwidth-code-point": "^2.0.0"
 					}
 				},
@@ -939,9 +1129,9 @@
 					"dev": true
 				},
 				"source-map-support": {
-					"version": "0.5.6",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"version": "0.5.12",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -955,6 +1145,14 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"dev": true
+						}
 					}
 				},
 				"supports-color": {
@@ -967,52 +1165,154 @@
 					}
 				},
 				"table": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
-					"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+					"version": "5.4.5",
+					"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+					"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.0.1",
-						"ajv-keywords": "^3.0.0",
-						"chalk": "^2.1.0",
-						"lodash": "^4.17.4",
-						"slice-ansi": "1.0.0",
-						"string-width": "^2.1.1"
+						"ajv": "^6.10.2",
+						"lodash": "^4.17.14",
+						"slice-ansi": "^2.1.0",
+						"string-width": "^3.0.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "6.10.2",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+							"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^2.0.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						},
+						"lodash": {
+							"version": "4.17.15",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
 					}
 				},
-				"xregexp": {
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
+					}
+				},
+				"y18n": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-					"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yargs": {
-					"version": "12.0.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
-					"integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+					"version": "13.2.4",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^2.0.0",
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^10.1.0"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.0"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
 					}
 				},
 				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -1024,12 +1324,29 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-			"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
 			"dev": true,
 			"requires": {
 				"es6-promisify": "^5.0.0"
+			},
+			"dependencies": {
+				"es6-promise": {
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+					"dev": true
+				},
+				"es6-promisify": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.0.3"
+					}
+				}
 			}
 		},
 		"ajv": {
@@ -1050,9 +1367,9 @@
 			"dev": true
 		},
 		"ajv-keywords": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
 		"ajv-merge-patch": {
@@ -1118,6 +1435,17 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"aproba": {
@@ -1143,36 +1471,20 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-					"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+					"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.11"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
+						"lodash": "^4.17.14"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.15",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -1191,28 +1503,13 @@
 				"readable-stream": "^2.0.0"
 			},
 			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -1343,11 +1640,12 @@
 			}
 		},
 		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"dev": true,
 			"requires": {
+				"object-assign": "^4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -1380,9 +1678,9 @@
 			"dev": true
 		},
 		"ast-types": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz",
-			"integrity": "sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg==",
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
+			"integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
 			"dev": true
 		},
 		"astral-regex": {
@@ -1398,9 +1696,9 @@
 			"dev": true
 		},
 		"async-each": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-			"integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"async-limiter": {
@@ -1449,20 +1747,20 @@
 			}
 		},
 		"babel-polyfill": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
+			"integrity": "sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"regenerator-runtime": "^0.10.5"
+				"babel-runtime": "^6.9.1",
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.9.5"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+					"version": "0.9.6",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+					"integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
 					"dev": true
 				}
 			}
@@ -1475,6 +1773,14 @@
 			"requires": {
 				"core-js": "^2.4.0",
 				"regenerator-runtime": "^0.11.0"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+					"dev": true
+				}
 			}
 		},
 		"balanced-match": {
@@ -1559,9 +1865,9 @@
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"bl": {
@@ -1572,38 +1878,12 @@
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"bluebird": {
-			"version": "2.9.34",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-			"integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
 			"dev": true
 		},
 		"bn.js": {
@@ -1878,43 +2158,51 @@
 			}
 		},
 		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cacache": {
-			"version": "11.3.2",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+			"version": "11.3.3",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.3",
+				"bluebird": "^3.5.5",
 				"chownr": "^1.1.1",
 				"figgy-pudding": "^3.5.1",
-				"glob": "^7.1.3",
+				"glob": "^7.1.4",
 				"graceful-fs": "^4.1.15",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.2",
+				"rimraf": "^2.6.3",
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
-				"bluebird": {
-					"version": "3.5.4",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-					"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
-					"dev": true
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
 				},
 				"graceful-fs": {
-					"version": "4.1.15",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
 					"dev": true
 				},
 				"lru-cache": {
@@ -1955,6 +2243,44 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
+			}
+		},
+		"cacheable-request": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"dev": true,
+			"requires": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^3.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^4.1.0",
+				"responselike": "^1.0.2"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				},
+				"normalize-url": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+					"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+					"dev": true
+				}
 			}
 		},
 		"call-me-maybe": {
@@ -2033,13 +2359,13 @@
 			"dev": true
 		},
 		"cheerio": {
-			"version": "1.0.0-rc.2",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-			"integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+			"version": "1.0.0-rc.3",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
 			"dev": true,
 			"requires": {
 				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.0",
+				"dom-serializer": "~0.1.1",
 				"entities": "~1.1.1",
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
@@ -2047,9 +2373,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-			"integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -2067,14 +2393,14 @@
 			},
 			"dependencies": {
 				"fsevents": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-					"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+					"version": "1.2.9",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+					"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -2086,7 +2412,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -2107,12 +2434,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -2127,17 +2456,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -2146,12 +2478,12 @@
 							"optional": true
 						},
 						"debug": {
-							"version": "2.6.9",
+							"version": "4.1.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"ms": "2.0.0"
+								"ms": "^2.1.1"
 							}
 						},
 						"deep-extend": {
@@ -2254,7 +2586,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -2266,6 +2599,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -2280,6 +2614,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -2287,12 +2622,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -2311,29 +2648,30 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
-							"version": "2.0.0",
+							"version": "2.1.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
-							"version": "2.2.4",
+							"version": "2.3.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"debug": "^2.1.2",
+								"debug": "^4.1.0",
 								"iconv-lite": "^0.4.4",
 								"sax": "^1.2.4"
 							}
 						},
 						"node-pre-gyp": {
-							"version": "0.10.3",
+							"version": "0.12.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
@@ -2361,13 +2699,13 @@
 							}
 						},
 						"npm-bundled": {
-							"version": "1.0.5",
+							"version": "1.0.6",
 							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
-							"version": "1.2.0",
+							"version": "1.4.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
@@ -2391,7 +2729,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -2403,6 +2742,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -2488,7 +2828,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -2503,7 +2844,7 @@
 							"optional": true
 						},
 						"semver": {
-							"version": "5.6.0",
+							"version": "5.7.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true
@@ -2524,6 +2865,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -2543,6 +2885,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -2586,39 +2929,29 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"upath": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-					"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
-					"dev": true
 				}
 			}
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
 			"dev": true
 		},
 		"chrome-trace-event": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-			"integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -2798,6 +3131,15 @@
 				}
 			}
 		},
+		"clone-response": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2852,17 +3194,17 @@
 			}
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"dev": true
 		},
 		"common-tags": {
@@ -2895,28 +3237,13 @@
 				"readable-stream": "^2.0.0"
 			},
 			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
+						"remove-trailing-separator": "^1.0.1"
 					}
 				}
 			}
@@ -2937,32 +3264,6 @@
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.2.2",
 				"typedarray": "^0.0.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"configstore": {
@@ -3021,24 +3322,45 @@
 			"dev": true
 		},
 		"copy-webpack-plugin": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.0.2.tgz",
-			"integrity": "sha512-7nC7EynPrnBTtBwwbG1aTqrfNS1aTb9eEjSmQDqFtKAsJrR3uDb+pCDIFT2LzhW+SgGJxQcYzThrmXzzZ720uw==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.0.4.tgz",
+			"integrity": "sha512-YBuYGpSzoCHSSDGyHy6VJ7SHojKp6WHT4D7ItcQFNAYx2hrwkMe56e97xfVR0/ovDuMTrMffXUiltvQljtAGeg==",
 			"dev": true,
 			"requires": {
-				"cacache": "^11.3.1",
-				"find-cache-dir": "^2.0.0",
+				"cacache": "^11.3.3",
+				"find-cache-dir": "^2.1.0",
 				"glob-parent": "^3.1.0",
 				"globby": "^7.1.1",
-				"is-glob": "^4.0.0",
-				"loader-utils": "^1.1.0",
+				"is-glob": "^4.0.1",
+				"loader-utils": "^1.2.3",
 				"minimatch": "^3.0.4",
 				"normalize-path": "^3.0.0",
-				"p-limit": "^2.1.0",
-				"serialize-javascript": "^1.4.0",
+				"p-limit": "^2.2.0",
+				"schema-utils": "^1.0.0",
+				"serialize-javascript": "^1.7.0",
 				"webpack-log": "^2.0.0"
 			},
 			"dependencies": {
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"globby": {
 					"version": "7.1.1",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
@@ -3051,6 +3373,14 @@
 						"ignore": "^3.3.5",
 						"pify": "^3.0.0",
 						"slash": "^1.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+							"dev": true
+						}
 					}
 				},
 				"ignore": {
@@ -3059,11 +3389,34 @@
 					"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
 					"dev": true
 				},
-				"normalize-path": {
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"locate-path": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
 				},
 				"p-limit": {
 					"version": "2.2.0",
@@ -3074,16 +3427,46 @@
 						"p-try": "^2.0.0"
 					}
 				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
 				"p-try": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pify": {
+				"path-exists": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"slash": {
@@ -3132,32 +3515,6 @@
 			"requires": {
 				"crc": "^3.4.4",
 				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"create-ecdh": {
@@ -3269,22 +3626,22 @@
 			"dev": true
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"requires": {
 				"cssom": "0.3.x"
 			}
 		},
 		"csstype": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
-			"integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
 			"dev": true
 		},
 		"currently-unhandled": {
@@ -3303,12 +3660,13 @@
 			"dev": true
 		},
 		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
 			"dev": true,
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -3320,18 +3678,18 @@
 			}
 		},
 		"data-uri-to-buffer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.0.tgz",
-			"integrity": "sha512-YbKCNLPPP4inc0E5If4OaalBc7gpaM2MRv77Pv2VThVComLKfbGYtJcdDCViDyp1Wd4SebhHLz94vp91zbK6bw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz",
+			"integrity": "sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==",
 			"dev": true,
 			"requires": {
 				"@types/node": "^8.0.7"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.45",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
-					"integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==",
+					"version": "8.10.51",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
+					"integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==",
 					"dev": true
 				}
 			}
@@ -3353,9 +3711,9 @@
 			"dev": true
 		},
 		"debounce": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
-			"integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+			"integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
 			"dev": true
 		},
 		"debug": {
@@ -3388,6 +3746,15 @@
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
 		},
 		"deep-equal": {
 			"version": "1.0.1",
@@ -3422,9 +3789,9 @@
 			"dev": true
 		},
 		"deepmerge": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-			"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+			"integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
 			"dev": true
 		},
 		"defaults": {
@@ -3435,6 +3802,12 @@
 			"requires": {
 				"clone": "^1.0.2"
 			}
+		},
+		"defer-to-connect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+			"integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -3538,6 +3911,12 @@
 			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
 		},
+		"diff": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+			"dev": true
+		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -3576,35 +3955,59 @@
 			}
 		},
 		"dispensary": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.27.0.tgz",
-			"integrity": "sha512-bG9pSBPH8wTEaugUIBAbBvBHynqOoGxefOT4YXlPoUc9AxQGDUO1uFHafDVWnsGWiSYvTUga0aZ9xThzfGQtlQ==",
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/dispensary/-/dispensary-0.37.0.tgz",
+			"integrity": "sha512-Baqbt8MDkRYQZHB7XEd8iBUP8wRkRLjNWbm16nSDTOIoGvgF4Z8Q9wV1yD72TYjFC0kj1/o3nfPXPiAvWqjC8g==",
 			"dev": true,
 			"requires": {
 				"array-from": "~2.1.1",
-				"async": "~2.6.0",
+				"async": "~3.0.0",
 				"natural-compare-lite": "~1.4.0",
-				"pino": "~5.8.0",
+				"pino": "~5.12.0",
 				"request": "~2.88.0",
 				"sha.js": "~2.4.4",
+				"snyk": "^1.165.1",
 				"source-map-support": "~0.5.4",
-				"yargs": "~12.0.1"
+				"yargs": "~13.2.0"
 			},
 			"dependencies": {
-				"async": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-					"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"lodash": "^4.17.11"
+						"color-convert": "^1.9.0"
 					}
 				},
-				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+				"async": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.0.1.tgz",
+					"integrity": "sha512-ZswD8vwPtmBZzbn9xyi8XBQWXH3AvOQ43Za1KWYq7JeycrZuUYzx01KvHcVbXltjqH4y0MWrQ33008uLTqXuDw==",
 					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
 				},
 				"execa": {
 					"version": "1.0.0",
@@ -3629,6 +4032,12 @@
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
 				},
 				"get-stream": {
 					"version": "4.1.0",
@@ -3665,9 +4074,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -3676,9 +4085,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
 				"os-locale": {
@@ -3711,9 +4120,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"path-exists": {
@@ -3722,62 +4131,72 @@
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
-				"pino": {
-					"version": "5.8.1",
-					"resolved": "https://registry.npmjs.org/pino/-/pino-5.8.1.tgz",
-					"integrity": "sha512-7bVFzUw3ffIfOM3t7MuQ9KsH+wX5bdGdQhGfccKgleoY7qG4FO3CmVSjywlFmmYGyMOISi1LDGC6JMEH7XkZJg==",
-					"dev": true,
-					"requires": {
-						"fast-json-parse": "^1.0.3",
-						"fast-redact": "^1.2.0",
-						"fast-safe-stringify": "^2.0.6",
-						"flatstr": "^1.0.5",
-						"pino-std-serializers": "^2.3.0",
-						"pump": "^3.0.0",
-						"quick-format-unescaped": "^3.0.0",
-						"sonic-boom": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 					"dev": true
 				},
-				"source-map-support": {
-					"version": "0.5.11",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-					"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
 					}
 				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.2.4",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -3787,9 +4206,9 @@
 			}
 		},
 		"dockerfile-ast": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.12.tgz",
-			"integrity": "sha512-cIV8oXkAxpIuN5XgG0TGg07nLDgrj4olkfrdT77OTA3VypscsYHBUg/FjHxW9K3oA+CyH4Th/qtoMgTVpzSobw==",
+			"version": "0.0.16",
+			"resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.0.16.tgz",
+			"integrity": "sha512-+HZToHjjiLPl46TqBrok5dMrg5oCkZFPSROMQjRmvin0zG4FxK0DJXTpV/CUPYY2zpmEvVza55XLwSHFx/xZMw==",
 			"dev": true,
 			"requires": {
 				"vscode-languageserver-types": "^3.5.0"
@@ -3811,14 +4230,19 @@
 			}
 		},
 		"dom-chef": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/dom-chef/-/dom-chef-3.6.0.tgz",
-			"integrity": "sha512-MW8lnAPzUiCbJMsCnmzwfMVSB/ew9wB5WenYt7N7FCobc4lrx3EEV7cz3IYJ9x5oF96GLysuQwV4PIWFnaQCPw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/dom-chef/-/dom-chef-3.6.1.tgz",
+			"integrity": "sha512-lCkWLi0+C3JQ/lAQVja/Z22/pH1M5075VwLrkFkq8O/CUyrAcXhmyRlNZAJhDAXOIxnCJHROvL0XpOoTF6N1Mw==",
 			"requires": {
 				"arr-flatten": "^1.0.3",
 				"jsdom": "^13.1.0",
 				"svg-tag-names": "^1.1.1"
 			}
+		},
+		"dom-loaded": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/dom-loaded/-/dom-loaded-1.2.0.tgz",
+			"integrity": "sha512-frk62k79SnSCCKqYY/lKofs0a8WPGBtQryX9jwObiyYl4WIm+G6TjDMmxoIkE7czrA/KKnVKXjHFbUjePH8MCg=="
 		},
 		"dom-serializer": {
 			"version": "0.1.1",
@@ -3920,32 +4344,6 @@
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0",
 				"stream-shift": "^1.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"ecc-jsbn": {
@@ -3967,17 +4365,26 @@
 			}
 		},
 		"element-ready": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-3.1.0.tgz",
-			"integrity": "sha512-WRpBdfIvKK5hpXb40PK63YxI+kBQvkYd6SMfAGUrTHwFKpiq1WnIoLGIgepZrzwVHQMz/4STLiaSyMpwHWBeDg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/element-ready/-/element-ready-4.1.0.tgz",
+			"integrity": "sha512-dmUj8ppNnnzGf/CUXPr+p1khFffvUQrBquuDRYKzIzVQxnDa9SNpNiGzOqhYTQ3l8okPJmKr0j0w8oiB77T6UQ==",
 			"requires": {
-				"p-cancelable": "^1.1.0"
+				"dom-loaded": "^1.1.0",
+				"many-keys-map": "^1.0.1",
+				"p-defer": "^2.1.0"
+			},
+			"dependencies": {
+				"p-defer": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-2.1.0.tgz",
+					"integrity": "sha512-xMwL9id1bHn/UfNGFEMFwlULOprQUEOg6vhqSfr6oKxPFB0oSh0zhGq/9/tPSE+cyij2+RW6H8+0Ke4xsPdZ7Q=="
+				}
 			}
 		},
 		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -3993,6 +4400,12 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
 			"integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
 		},
 		"emojis-list": {
@@ -4095,9 +4508,9 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.49",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
-			"integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+			"version": "0.10.50",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+			"integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
 			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
@@ -4143,21 +4556,10 @@
 			"dev": true
 		},
 		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"dev": true,
-			"requires": {
-				"es6-promise": "^4.0.3"
-			},
-			"dependencies": {
-				"es6-promise": {
-					"version": "4.2.6",
-					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-					"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
-					"dev": true
-				}
-			}
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.1.tgz",
+			"integrity": "sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==",
+			"dev": true
 		},
 		"es6-set": {
 			"version": "0.1.5",
@@ -4183,14 +4585,14 @@
 			}
 		},
 		"es6-weak-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
 			"dev": true,
 			"requires": {
 				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.1"
 			}
 		},
@@ -4238,54 +4640,66 @@
 			}
 		},
 		"eslint": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.0.tgz",
-			"integrity": "sha512-LntwyPxtOHrsJdcSwyQKVtHofPHdv+4+mFwEe91r2V13vqpM8yLr7b1sW+Oo/yheOPkWYsYlYJCkzlFAt8KV7g==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
+			"integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.5.3",
+				"ajv": "^6.10.0",
 				"chalk": "^2.1.0",
 				"cross-spawn": "^6.0.5",
 				"debug": "^4.0.1",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^4.0.0",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^5.0.0",
 				"eslint-utils": "^1.3.1",
 				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.0",
+				"espree": "^6.0.0",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
+				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
+				"glob-parent": "^5.0.0",
 				"globals": "^11.7.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.1.0",
-				"js-yaml": "^3.12.0",
+				"inquirer": "^6.4.1",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.3.0",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.14",
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
-				"semver": "^5.5.1",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
-				"table": "^5.0.2",
-				"text-table": "^0.2.0"
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -4308,14 +4722,85 @@
 						"supports-color": "^5.3.0"
 					}
 				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"esutils": "^2.0.2"
 					}
+				},
+				"eslint-scope": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+					"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
+					}
+				},
+				"glob-parent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
+					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "4.0.1",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+							"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+							"dev": true,
+							"requires": {
+								"is-extglob": "^2.1.1"
+							}
+						}
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
@@ -4324,6 +4809,15 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
 					}
 				}
 			}
@@ -4362,9 +4856,9 @@
 			"dev": true
 		},
 		"eslint-config-xo-typescript": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.9.0.tgz",
-			"integrity": "sha512-/poC4tfdjBBCWRh5sbpoNtF+2TR1PIlCdPGV5ZidYlgHHWCmREFmfKLPMG9RZY+vs+O7sM0DTF4ox9C7LhLBeA==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-xo-typescript/-/eslint-config-xo-typescript-0.15.0.tgz",
+			"integrity": "sha512-VDZj8JogA2qzgLQfp4nWPotJfO84dSkcze7n/3xiIpPIfa8oAdxGYv6N6RRdG2A4trMPQEiFESxFSIf/0155/A==",
 			"dev": true
 		},
 		"eslint-formatter-pretty": {
@@ -4826,6 +5320,22 @@
 					"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
 					"dev": true
 				},
+				"require-uncached": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+					"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^0.1.0",
+						"resolve-from": "^1.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+					"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+					"dev": true
+				},
 				"run-async": {
 					"version": "0.1.0",
 					"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -4833,17 +5343,6 @@
 					"dev": true,
 					"requires": {
 						"once": "^1.3.0"
-					}
-				},
-				"shelljs": {
-					"version": "0.7.8",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-					"dev": true,
-					"requires": {
-						"glob": "^7.0.0",
-						"interpret": "^1.0.0",
-						"rechoir": "^0.6.2"
 					}
 				},
 				"slice-ansi": {
@@ -5018,14 +5517,22 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-			"integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+			"integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.2",
+				"acorn": "^6.0.7",
 				"acorn-jsx": "^5.0.0",
 				"eslint-visitor-keys": "^1.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -5328,19 +5835,13 @@
 				"micromatch": "^3.1.10"
 			}
 		},
-		"fast-json-parse": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-			"integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-			"dev": true
-		},
 		"fast-json-patch": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.0.7.tgz",
-			"integrity": "sha512-DQeoEyPYxdTtfmB3yDlxkLyKTdbJ6ABfFGcMynDqjvGhPYLto/pZyb/dG2Nyd/n9CArjEWN9ZST++AFmgzgbGw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.0.tgz",
+			"integrity": "sha512-LdR6I9Cukps4lPUbSwrk81EHYo2XKsMnbiJJDQyBGGX7oTGovqBFxSVqQ+gOVoMxWfI1ua0vlHcXGpIggxtEFA==",
 			"dev": true,
 			"requires": {
-				"deep-equal": "^1.0.1"
+				"fast-deep-equal": "^2.0.1"
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -5510,26 +6011,15 @@
 			}
 		},
 		"findup-sync": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
 			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
-				"is-glob": "^3.1.0",
+				"is-glob": "^4.0.0",
 				"micromatch": "^3.0.4",
 				"resolve-dir": "^1.0.1"
-			},
-			"dependencies": {
-				"is-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.0"
-					}
-				}
 			}
 		},
 		"firefox-profile": {
@@ -5563,39 +6053,10 @@
 			}
 		},
 		"first-chunk-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
-			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-3.0.0.tgz",
+			"integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw==",
+			"dev": true
 		},
 		"flat-cache": {
 			"version": "1.3.4",
@@ -5610,15 +6071,21 @@
 			}
 		},
 		"flatstr": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.9.tgz",
-			"integrity": "sha512-qFlJnOBWDfIaunF54/lBqNKmXOI0HqNhu+mHkLmbaBXlS71PUd9OjFOdyevHt/aHoHB1+eW7eKHgRKOG5aHSpw==",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
+			"dev": true
+		},
+		"flatted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
 			"dev": true
 		},
 		"fluent-syntax": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.7.0.tgz",
-			"integrity": "sha512-T0iqfhC40jrs3aDjYOKgzIQjjhsH2Fa6LnXB6naPv0ymW3DeYMUFa89y9aLKMpi1P9nl2vEimK7blx4tVnUWBg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.13.0.tgz",
+			"integrity": "sha512-0Bk1AsliuYB550zr4JV9AYhsETsD3ELXUQzdXGJfIc1Ni/ukAfBdQInDhVMYJUaT2QxoamNslwkYF7MlOrPUwg==",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -5629,32 +6096,6 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.3.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"for-in": {
@@ -5704,32 +6145,6 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"fs-constants": {
@@ -5759,32 +6174,6 @@
 				"iferr": "^0.1.5",
 				"imurmurhash": "^0.1.4",
 				"readable-stream": "1 || 2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"fs.realpath": {
@@ -5794,9 +6183,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.1.tgz",
-			"integrity": "sha512-p+CXqK/iLvDESUWdn3NA3JVO9HxdfI+iXx8xR3DqWgKZvQNiEVpAyUQo0lmwz8rqksb4xaGerG291xuwwhX2kA==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -5849,13 +6238,12 @@
 			"dev": true
 		},
 		"fx-runner": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.9.tgz",
-			"integrity": "sha1-eyPzdz3HaqzELxHZr/J2lnXLY/A=",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.0.11.tgz",
+			"integrity": "sha512-igHogHf5wTqqaPPTOav18MMTVq/eoeTJiw/PvPUuwnzU8vbyZInFPgR66G9ZBwvwxC7e611nbtB4xSMcYVhlvg==",
 			"dev": true,
 			"requires": {
 				"commander": "2.9.0",
-				"lodash": "4.17.10",
 				"shell-quote": "1.6.1",
 				"spawn-sync": "1.0.15",
 				"when": "3.7.7",
@@ -5876,12 +6264,6 @@
 					"version": "1.1.2",
 					"resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
 					"integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
 					"dev": true
 				},
 				"which": {
@@ -5950,6 +6332,19 @@
 				"file-uri-to-path": "1",
 				"ftp": "~0.3.10",
 				"readable-stream": "3"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"get-value": {
@@ -5976,9 +6371,9 @@
 			}
 		},
 		"git-rev-sync": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz",
-			"integrity": "sha1-oMLj3TkqvPa3aWLif8dfsyI0Sc4=",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.12.0.tgz",
+			"integrity": "sha1-RGhAbH5sO6TPRYeZnhrbKNnRr1U=",
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "1.0.5",
@@ -5997,6 +6392,25 @@
 						"rechoir": "^0.6.2"
 					}
 				}
+			}
+		},
+		"git-up": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+			"integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"parse-url": "^5.0.0"
+			}
+		},
+		"git-url-parse": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+			"integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+			"dev": true,
+			"requires": {
+				"git-up": "^4.0.0"
 			}
 		},
 		"glob": {
@@ -6050,14 +6464,25 @@
 			}
 		},
 		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^1.0.1",
-				"is-windows": "^1.0.1",
-				"resolve-dir": "^1.0.0"
+				"global-prefix": "^3.0.0"
+			},
+			"dependencies": {
+				"global-prefix": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+					"dev": true,
+					"requires": {
+						"ini": "^1.3.5",
+						"kind-of": "^6.0.2",
+						"which": "^1.3.1"
+					}
+				}
 			}
 		},
 		"global-prefix": {
@@ -6254,23 +6679,6 @@
 			"integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
 			"dev": true
 		},
-		"hasbin": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
-			"integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
-			"dev": true,
-			"requires": {
-				"async": "~1.5"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				}
-			}
-		},
 		"hash-base": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
@@ -6301,12 +6709,6 @@
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"home-or-tmp": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
-			"integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
-			"dev": true
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -6343,18 +6745,46 @@
 				"entities": "^1.1.1",
 				"inherits": "^2.0.1",
 				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
+		"http-cache-semantics": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+			"dev": true
+		},
 		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
 			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				}
 			}
 		},
 		"http-proxy-agent": {
@@ -6401,12 +6831,12 @@
 			"dev": true
 		},
 		"https-proxy-agent": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-			"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
+				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
 			},
 			"dependencies": {
@@ -6430,9 +6860,9 @@
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
 			"dev": true
 		},
 		"iferr": {
@@ -6560,10 +6990,10 @@
 				"repeating": "^2.0.0"
 			}
 		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+		"infer-owner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
 			"dev": true
 		},
 		"inflight": {
@@ -6589,30 +7019,36 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-			"integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
+				"ansi-escapes": "^3.2.0",
+				"chalk": "^2.4.2",
 				"cli-cursor": "^2.1.0",
 				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.0",
+				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.12",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
-				"rxjs": "^6.1.0",
+				"rxjs": "^6.4.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"ansi-regex": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -6664,12 +7100,12 @@
 					}
 				},
 				"strip-ansi": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
 				"supports-color": {
@@ -6910,9 +7346,9 @@
 			"dev": true
 		},
 		"is-my-json-valid": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-			"integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+			"integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
 			"dev": true,
 			"requires": {
 				"generate-function": "^2.0.0",
@@ -7043,6 +7479,15 @@
 			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 			"dev": true
 		},
+		"is-ssh": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+			"integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+			"dev": true,
+			"requires": {
+				"protocols": "^1.1.0"
+			}
+		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -7079,6 +7524,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
 			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"is-yarn-global": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
 			"dev": true
 		},
 		"isarray": {
@@ -7139,9 +7590,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-			"integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -7190,17 +7641,14 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
 					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
-				},
-				"tough-cookie": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-					"requires": {
-						"psl": "^1.1.28",
-						"punycode": "^2.1.1"
-					}
 				}
 			}
+		},
+		"json-buffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"dev": true
 		},
 		"json-merge-patch": {
 			"version": "0.2.3",
@@ -7307,41 +7755,15 @@
 			}
 		},
 		"jszip": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.1.tgz",
-			"integrity": "sha512-iCMBbo4eE5rb1VCpm5qXOAaUiRKRUKiItn8ah2YQQx9qymmSAY98eyQfioChEYcVQLh0zxJ3wS4A0mh90AVPvw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+			"integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
 			"dev": true,
 			"requires": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"set-immediate-shim": "~1.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"junk": {
@@ -7369,6 +7791,15 @@
 			"requires": {
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"keyv": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
+			"requires": {
+				"json-buffer": "3.0.0"
 			}
 		},
 		"kind-of": {
@@ -7399,32 +7830,6 @@
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.0.5"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"lcid": {
@@ -7509,9 +7914,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -7604,9 +8009,9 @@
 			"dev": true
 		},
 		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
 			"dev": true
 		},
 		"lodash.once": {
@@ -7717,9 +8122,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
-			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
 			"dev": true
 		},
 		"make-dir": {
@@ -7744,6 +8149,11 @@
 			"resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
 			"integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
 			"dev": true
+		},
+		"many-keys-map": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-1.0.2.tgz",
+			"integrity": "sha512-bOXZsgmnTHkvWQCpq9WBnX5JNfJ1WTq9+QdzXe1UA3eu0+8llCrDSPOTKo1IVUrnzW0N0f9pZd95CDpKUC73uw=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -7786,6 +8196,15 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
+		"mdn-browser-compat-data": {
+			"version": "0.0.82",
+			"resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.82.tgz",
+			"integrity": "sha512-RmC87C45AgXLuNlkrGLCK2wh0zRwpFnnro5jsNxmS90xLCxfKmTLPtqM9cocKFD7Ro9pWmtvkIkRiesGakd1Ig==",
+			"dev": true,
+			"requires": {
+				"extend": "3.0.2"
+			}
+		},
 		"mem": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -7803,32 +8222,6 @@
 			"requires": {
 				"errno": "^0.1.3",
 				"readable-stream": "^2.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"memorystream": {
@@ -7893,22 +8286,28 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
 		},
 		"mime-types": {
-			"version": "2.1.22",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"requires": {
-				"mime-db": "~1.38.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+			"dev": true
+		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"dev": true
 		},
 		"minimalistic-assert": {
@@ -7967,9 +8366,9 @@
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -8125,9 +8524,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
-			"integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 			"dev": true,
 			"optional": true
 		},
@@ -8245,37 +8644,31 @@
 			"optional": true
 		},
 		"needle": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
-			"integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+			"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.1.2",
+				"debug": "^3.2.6",
 				"iconv-lite": "^0.4.4",
 				"sax": "^1.2.4"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
 				}
 			}
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"netmask": {
@@ -8303,9 +8696,9 @@
 			"dev": true
 		},
 		"node-libs-browser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
 			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
@@ -8318,7 +8711,7 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.0",
+				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -8330,7 +8723,7 @@
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
 				"util": "^0.11.0",
-				"vm-browserify": "0.0.4"
+				"vm-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"buffer": {
@@ -8349,58 +8742,18 @@
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					},
-					"dependencies": {
-						"string_decoder": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-							"dev": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"util": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-					"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
 				}
 			}
 		},
-		"node-modules-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-			"dev": true
-		},
 		"node-notifier": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-			"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
-				"semver": "^5.4.1",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
 			}
@@ -8459,13 +8812,16 @@
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
+		"normalize-url": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+			"dev": true
 		},
 		"npm-run-all": {
 			"version": "4.1.5",
@@ -8594,9 +8950,9 @@
 			"dev": true
 		},
 		"nwsapi": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.3.tgz",
-			"integrity": "sha512-RowAaJGEgYXEZfQ7tvvdtAQUKPyTR6T6wNu0fwlNsGQYr/h3yQc6oI8WnVZh3Y/Sylwc+dtAlvPqfFZjhTyk3A=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+			"integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw=="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -8645,6 +9001,12 @@
 					}
 				}
 			}
+		},
+		"object-hash": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+			"integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.0",
@@ -8764,13 +9126,13 @@
 			}
 		},
 		"os-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
-			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
 			"dev": true,
 			"requires": {
-				"macos-release": "^1.0.0",
-				"win-release": "^1.0.0"
+				"macos-release": "^2.2.0",
+				"windows-release": "^3.1.0"
 			}
 		},
 		"os-shim": {
@@ -8788,7 +9150,8 @@
 		"p-cancelable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true
 		},
 		"p-defer": {
 			"version": "1.0.0",
@@ -8803,9 +9166,9 @@
 			"dev": true
 		},
 		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -8833,9 +9196,9 @@
 			"dev": true
 		},
 		"pac-proxy-agent": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
-			"integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz",
+			"integrity": "sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.2.0",
@@ -8845,7 +9208,7 @@
 				"https-proxy-agent": "^2.2.1",
 				"pac-resolver": "^3.0.0",
 				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "^3.0.0"
+				"socks-proxy-agent": "^4.0.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -8899,32 +9262,6 @@
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"parent-module": {
@@ -8965,6 +9302,28 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
+		"parse-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+			"integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"protocols": "^1.4.0"
+			}
+		},
+		"parse-url": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+			"integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+			"dev": true,
+			"requires": {
+				"is-ssh": "^1.3.0",
+				"normalize-url": "^3.3.0",
+				"parse-path": "^4.0.0",
+				"protocols": "^1.4.0"
+			}
+		},
 		"parse5": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
@@ -8980,20 +9339,10 @@
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
 			"dev": true
 		},
-		"path": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-			"integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-			"dev": true,
-			"requires": {
-				"process": "^0.11.1",
-				"util": "^0.10.3"
-			}
-		},
 		"path-browserify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
 		},
 		"path-dirname": {
@@ -9070,6 +9419,12 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
+		"picomatch": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+			"dev": true
+		},
 		"pidtree": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -9098,35 +9453,24 @@
 			}
 		},
 		"pino": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-5.9.0.tgz",
-			"integrity": "sha512-6sHy38gWsZbrmYq6vk343VCThy93ZdVfmLsHDVzbl/j621SjSaxCcS/ySmxK/hRmq8jpQb3n44dNRIeqbbQw6A==",
+			"version": "5.12.6",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-5.12.6.tgz",
+			"integrity": "sha512-LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==",
 			"dev": true,
 			"requires": {
-				"fast-json-parse": "^1.0.3",
-				"fast-redact": "^1.4.0",
+				"fast-redact": "^1.4.4",
 				"fast-safe-stringify": "^2.0.6",
-				"flatstr": "^1.0.5",
+				"flatstr": "^1.0.9",
 				"pino-std-serializers": "^2.3.0",
-				"pump": "^3.0.0",
-				"quick-format-unescaped": "^3.0.0",
-				"sonic-boom": "^0.6.3"
+				"quick-format-unescaped": "^3.0.2",
+				"sonic-boom": "^0.7.3"
 			}
 		},
 		"pino-std-serializers": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.3.0.tgz",
-			"integrity": "sha512-klfGoOsP6sJH7ON796G4xoUSx2fkpFgKHO4YVVO2zmz31jR+etzc/QzGJILaOIiCD6HTCFgkPx+XN8nk+ruqPw==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
 			"dev": true
-		},
-		"pirates": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-			"dev": true,
-			"requires": {
-				"node-modules-regexp": "^1.0.0"
-			}
 		},
 		"pkg-conf": {
 			"version": "2.1.0",
@@ -9221,12 +9565,6 @@
 				"irregular-plurals": "^2.0.0"
 			}
 		},
-		"pluralize": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-			"dev": true
-		},
 		"pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -9249,14 +9587,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
-			"integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
+			"integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
-				"supports-color": "^5.5.0"
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9277,6 +9615,17 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
 					}
 				},
 				"source-map": {
@@ -9286,9 +9635,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -9340,6 +9689,14 @@
 				"next-tick": "^1.0.0",
 				"request": "^2.83.0",
 				"stream-parser": "~0.3.1"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+					"integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+					"dev": true
+				}
 			}
 		},
 		"process": {
@@ -9349,9 +9706,9 @@
 			"dev": true
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
 		"progress": {
@@ -9381,10 +9738,16 @@
 			"integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
 			"dev": true
 		},
+		"protocols": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+			"integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+			"dev": true
+		},
 		"proxy-agent": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
-			"integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.0.tgz",
+			"integrity": "sha512-IkbZL4ClW3wwBL/ABFD2zJ8iP84CY0uKMvBPk/OceQe/cEjrxzN1pMHsLwhbzUoRhG9QbSxYC+Z7LBkTiBNvrA==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.2.0",
@@ -9392,9 +9755,9 @@
 				"http-proxy-agent": "^2.1.0",
 				"https-proxy-agent": "^2.2.1",
 				"lru-cache": "^4.1.2",
-				"pac-proxy-agent": "^2.0.1",
+				"pac-proxy-agent": "^3.0.0",
 				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^3.0.0"
+				"socks-proxy-agent": "^4.0.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -9427,9 +9790,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -9532,26 +9895,15 @@
 			}
 		},
 		"raw-body": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.23",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.3",
+				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
 			}
 		},
 		"rc": {
@@ -9588,14 +9940,18 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-			"integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readdirp": {
@@ -9607,32 +9963,6 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"readline2": {
@@ -9692,9 +10022,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
 			"dev": true
 		},
 		"regex-not": {
@@ -9729,15 +10059,6 @@
 				"yargs": "^10.0.3"
 			}
 		},
-		"regexp.prototype.flags": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2"
-			}
-		},
 		"regexpp": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -9764,13 +10085,44 @@
 			}
 		},
 		"relaxed-json": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.1.tgz",
-			"integrity": "sha1-fI1KovCVcEzQIOMugJm8rhA/C9Q=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
+			"integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.0.0",
+				"chalk": "^2.4.2",
 				"commander": "^2.6.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"remove-trailing-separator": {
@@ -9825,6 +10177,22 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise-core": {
@@ -9858,9 +10226,9 @@
 			"dev": true
 		},
 		"require-uncached": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-2.0.0.tgz",
+			"integrity": "sha512-rPv1//BQwg4gzIbpJcKXWIfjDJEtgS8jzbsNoLcdVSE5FpBzKEKKuoG6MfCbLC28ZTv+qlQWC9/K7J5GBGPSMg==",
 			"dev": true,
 			"requires": {
 				"caller-path": "^0.1.0",
@@ -9874,12 +10242,6 @@
 					"dev": true
 				}
 			}
-		},
-		"requireindex": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-			"integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-			"dev": true
 		},
 		"resolve": {
 			"version": "1.9.0",
@@ -9915,6 +10277,19 @@
 			"requires": {
 				"expand-tilde": "^2.0.0",
 				"global-modules": "^1.0.0"
+			},
+			"dependencies": {
+				"global-modules": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^1.0.1",
+						"is-windows": "^1.0.1",
+						"resolve-dir": "^1.0.0"
+					}
+				}
 			}
 		},
 		"resolve-from": {
@@ -9928,6 +10303,15 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
 			"dev": true
+		},
+		"responselike": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
+			"requires": {
+				"lowercase-keys": "^1.0.0"
+			}
 		},
 		"restore-cursor": {
 			"version": "1.0.1",
@@ -9988,19 +10372,10 @@
 			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
 			"dev": true
 		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "*"
-			}
-		},
 		"rxjs": {
-			"version": "6.3.3",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
@@ -10039,11 +10414,11 @@
 			"dev": true
 		},
 		"saxes": {
-			"version": "3.1.9",
-			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
-			"integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
 			"requires": {
-				"xmlchars": "^1.3.1"
+				"xmlchars": "^2.1.1"
 			}
 		},
 		"schema-utils": {
@@ -10064,9 +10439,9 @@
 			"dev": true
 		},
 		"select-dom": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-5.0.1.tgz",
-			"integrity": "sha512-cpNrVqu6spg6B7bA5J8latFzHOXWh2UWYrVheemrnEfJQduUXmoVZZtgRiWTOe/axNoWsRODJ1otgy2f7Vol7g=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/select-dom/-/select-dom-5.1.0.tgz",
+			"integrity": "sha512-roC9kDCsz/xxio7LJtr7VGiJ163MBcl9emB0jIXdvahdUdvTO2wD91diHxUR9EjrG7XSyXOyH+QaqgPLGZOiFg=="
 		},
 		"semver": {
 			"version": "5.5.1",
@@ -10102,9 +10477,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -10131,9 +10506,9 @@
 			"dev": true
 		},
 		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
 		},
 		"sha.js": {
@@ -10197,9 +10572,9 @@
 			}
 		},
 		"shelljs": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"version": "0.7.8",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"dev": true,
 			"requires": {
 				"glob": "^7.0.0",
@@ -10243,22 +10618,26 @@
 						"json-schema-traverse": "^0.3.0"
 					}
 				},
-				"babel-polyfill": {
-					"version": "6.16.0",
-					"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
-					"integrity": "sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI=",
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.9.1",
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.9.5"
-					}
-				},
 				"es6-error": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.0.0.tgz",
 					"integrity": "sha1-8JTHBB9mJZm7EnINoFnWucf/D0A=",
 					"dev": true
+				},
+				"es6-promise": {
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+					"dev": true
+				},
+				"es6-promisify": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.0.3"
+					}
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
@@ -10303,12 +10682,6 @@
 					"version": "1.4.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				},
-				"regenerator-runtime": {
-					"version": "0.9.6",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-					"integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck=",
 					"dev": true
 				},
 				"request": {
@@ -10418,9 +10791,9 @@
 			"dev": true
 		},
 		"slice-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-			"integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
@@ -10440,9 +10813,9 @@
 			}
 		},
 		"smart-buffer": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-			"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -10568,53 +10941,67 @@
 			}
 		},
 		"snyk": {
-			"version": "1.110.2",
-			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.110.2.tgz",
-			"integrity": "sha512-SQE4sudrscd48EoRJqy5h5S6c8YBiOw0r0Se3rfg1l6ElJGgCB9je6XEzfe+UmfES06D7ueFYepiQPxTwH4Qww==",
+			"version": "1.208.0",
+			"resolved": "https://registry.npmjs.org/snyk/-/snyk-1.208.0.tgz",
+			"integrity": "sha512-MMOQazfz+5fvoCDEBBJiuYNdcrtE3anemGvL7VJFlWu4uc8YgVZ8gvetEO7OmLmn4FfTmJ/hAthEQgcXYjDjFw==",
 			"dev": true,
 			"requires": {
+				"@snyk/dep-graph": "1.10.0",
+				"@snyk/gemfile": "1.2.0",
+				"@types/agent-base": "^4.2.0",
 				"abbrev": "^1.1.1",
-				"ansi-escapes": "^3.1.0",
-				"chalk": "^2.4.1",
+				"ansi-escapes": "^4.1.0",
+				"chalk": "^2.4.2",
 				"configstore": "^3.1.2",
 				"debug": "^3.1.0",
-				"hasbin": "^1.2.3",
-				"inquirer": "^3.0.0",
-				"lodash": "^4.17.5",
+				"diff": "^4.0.1",
+				"git-url-parse": "11.1.2",
+				"glob": "^7.1.3",
+				"inquirer": "^6.2.2",
+				"lodash": "^4.17.14",
 				"needle": "^2.2.4",
-				"opn": "^5.2.0",
-				"os-name": "^2.0.1",
-				"proxy-agent": "^2.0.0",
+				"opn": "^5.5.0",
+				"os-name": "^3.0.0",
+				"proxy-agent": "^3.1.0",
 				"proxy-from-env": "^1.0.0",
-				"recursive-readdir": "^2.2.2",
-				"semver": "^5.5.0",
-				"snyk-config": "2.2.0",
-				"snyk-docker-plugin": "1.12.3",
-				"snyk-go-plugin": "1.6.0",
-				"snyk-gradle-plugin": "2.1.1",
+				"semver": "^6.0.0",
+				"snyk-config": "^2.2.1",
+				"snyk-docker-plugin": "1.25.1",
+				"snyk-go-plugin": "1.11.0",
+				"snyk-gradle-plugin": "2.12.5",
 				"snyk-module": "1.9.1",
-				"snyk-mvn-plugin": "2.0.0",
-				"snyk-nodejs-lockfile-parser": "1.7.1",
-				"snyk-nuget-plugin": "1.6.5",
-				"snyk-php-plugin": "1.5.1",
-				"snyk-policy": "1.13.1",
-				"snyk-python-plugin": "1.9.0",
+				"snyk-mvn-plugin": "2.3.1",
+				"snyk-nodejs-lockfile-parser": "1.16.0",
+				"snyk-nuget-plugin": "1.11.2",
+				"snyk-php-plugin": "1.6.4",
+				"snyk-policy": "1.13.5",
+				"snyk-python-plugin": "1.10.2",
 				"snyk-resolve": "1.0.1",
-				"snyk-resolve-deps": "4.0.2",
-				"snyk-sbt-plugin": "2.0.0",
+				"snyk-resolve-deps": "4.0.3",
+				"snyk-sbt-plugin": "2.6.1",
 				"snyk-tree": "^1.0.0",
 				"snyk-try-require": "1.3.1",
-				"source-map-support": "^0.5.9",
+				"source-map-support": "^0.5.11",
+				"strip-ansi": "^5.2.0",
 				"tempfile": "^2.0.0",
 				"then-fs": "^2.0.0",
-				"undefsafe": "^2.0.0",
-				"uuid": "^3.2.1"
+				"update-notifier": "^2.5.0",
+				"uuid": "^3.3.2"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+					"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.5.2"
+					}
+				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -10637,12 +11024,6 @@
 						"supports-color": "^5.3.0"
 					}
 				},
-				"chardet": {
-					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-					"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-					"dev": true
-				},
 				"cli-cursor": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -10661,38 +11042,40 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"external-editor": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-					"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-					"dev": true,
-					"requires": {
-						"chardet": "^0.4.0",
-						"iconv-lite": "^0.4.17",
-						"tmp": "^0.0.33"
-					}
-				},
 				"inquirer": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-					"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^2.0.4",
+						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.3.0",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rx-lite": "^4.0.8",
-						"rx-lite-aggregates": "^4.0.8",
+						"rxjs": "^6.4.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
+						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
+					},
+					"dependencies": {
+						"ansi-escapes": {
+							"version": "3.2.0",
+							"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+							"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+							"dev": true
+						}
 					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
 				},
 				"onetime": {
 					"version": "2.0.1",
@@ -10701,6 +11084,15 @@
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
+					}
+				},
+				"opn": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+					"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+					"dev": true,
+					"requires": {
+						"is-wsl": "^1.1.0"
 					}
 				},
 				"restore-cursor": {
@@ -10713,35 +11105,28 @@
 						"signal-exit": "^3.0.2"
 					}
 				},
-				"rx-lite": {
-					"version": "4.0.8",
-					"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-					"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.11",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-					"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+				"rxjs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+					"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"tslib": "^1.9.0"
 					}
 				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
 				"supports-color": {
@@ -10756,13 +11141,13 @@
 			}
 		},
 		"snyk-config": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.0.tgz",
-			"integrity": "sha512-mq0wbP/AgjcmRq5i5jg2akVVV3iSYUPTowZwKn7DChRLDL8ySOzWAwan+ImXiyNbrWo87FNI/15O6MpOnTxOIg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-2.2.2.tgz",
+			"integrity": "sha512-ud1UJhU5b3z2achCVbXin6m3eeESvJTn9hBDYjp5BafI+1ajOJt0LnUB9+SAZ3CnQIK90PUb/3nSx0xjtda7sA==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
-				"lodash": "^4.17.5",
+				"lodash": "^4.17.14",
 				"nconf": "^0.10.0"
 			},
 			"dependencies": {
@@ -10774,49 +11159,109 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
 				}
 			}
 		},
 		"snyk-docker-plugin": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.12.3.tgz",
-			"integrity": "sha512-ZbvaFCPCd0wxhqxjzU/iyf39tKlq2nvI9nPW32uZV3RGdHrkQH55BzCtBCF9d0dapxX+PKgae/4u2BKNw8hd9Q==",
+			"version": "1.25.1",
+			"resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.25.1.tgz",
+			"integrity": "sha512-n/LfA7VXjPEcSz2ZfZonT/DPSC89Zs1/HD0inPFN4RLQT3WiQnjqJUXct+D0nWwEVfhLWNc+Y7PLcTjpnZ9R3Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^3",
-				"dockerfile-ast": "0.0.12",
+				"debug": "^4.1.1",
+				"dockerfile-ast": "0.0.16",
+				"semver": "^6.1.0",
 				"tslib": "^1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
-		"snyk-go-plugin": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.6.0.tgz",
-			"integrity": "sha512-E6aYw7XAXSs2wJR3fU+vGQ1lVyjAw8PHIQYQwBwMkTHByhJIWPcu6Hy/jT5LcjJHlhYXlpOuk53HeLVK+kcXrQ==",
+		"snyk-go-parser": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.3.1.tgz",
+			"integrity": "sha512-jrFRfIk6yGHFeipGD66WV9ei/A/w/lIiGqI80w1ndMbg6D6M5pVNbK7ngDTmo4GdHrZDYqx/VBGBsUm2bol3Rg==",
 			"dev": true,
 			"requires": {
+				"toml": "^3.0.0",
+				"tslib": "^1.9.3"
+			}
+		},
+		"snyk-go-plugin": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.11.0.tgz",
+			"integrity": "sha512-9hsGgloioGuey5hbZfv+MkFEslxXHyzUlaAazcR0NsY7VLyG/b2g3f88f/ZwCwlWaKL9LMv/ERIiey3oWAB/qg==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
 				"graphlib": "^2.1.1",
+				"snyk-go-parser": "1.3.1",
 				"tmp": "0.0.33",
-				"toml": "^2.3.2"
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"dev": true
+				}
 			}
 		},
 		"snyk-gradle-plugin": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.1.1.tgz",
-			"integrity": "sha512-aFeVC5y3XkJ5BxknHhtYo76as3xJbzSQlXACGZrQZGQ/w/UhNdM8VI1QB6Eq4uEzexleB/hcJwYxNmhI2CNCeA==",
+			"version": "2.12.5",
+			"resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.12.5.tgz",
+			"integrity": "sha512-AmiQQUL0nlY3SjWUSMSmmbp273ETJzsqvk1E8jf+G/Q3mRl9xZ6BkPMebweD/y5d/smoQmr6rKL57OG+OXoi3w==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^0.3.0"
+				"@types/debug": "^4.1.4",
+				"chalk": "^2.4.2",
+				"clone-deep": "^0.3.0",
+				"debug": "^4.1.1",
+				"tmp": "0.0.33",
+				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"snyk-module": {
@@ -10841,58 +11286,56 @@
 			}
 		},
 		"snyk-mvn-plugin": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.0.0.tgz",
-			"integrity": "sha512-9jAhZhv+7YcqtoQYCYlgMoxK+dWBKlk+wkX27Ebg3vNddNop9q5jZitRXTjsXwfSUZHRt+Ptw1f8vei9kjzZVg==",
-			"dev": true
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.3.1.tgz",
+			"integrity": "sha512-2RgBnYe3Upc7SL+sL7MmnoCoJV/TZZ7q2L0J1BAbjoD/4cca4q0TCR6QVLzytHf4fSqc6QjSMjTUfmAo0kgsBg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.13",
+				"tslib": "1.9.3"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				}
+			}
 		},
 		"snyk-nodejs-lockfile-parser": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.7.1.tgz",
-			"integrity": "sha512-0gHELqMhzUxb/t3Tg6d6G9LTDioOXCrEMt9aetOeV8wD/ZRL5VFNjwcdrm8qILLqzDFaFjFIyMc66c0OL4zFAQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.16.0.tgz",
+			"integrity": "sha512-cf3uozRXEG88nsjOQlo+SfOJPpcLs45qpnuk2vhBBZ577IMnV+fTOJQsP2YRiikLUbdgkVlduviwUO6OVn1PhA==",
 			"dev": true,
 			"requires": {
 				"@yarnpkg/lockfile": "^1.0.2",
 				"graphlib": "^2.1.5",
-				"lodash": "4.17.10",
+				"lodash": "^4.17.14",
 				"source-map-support": "^0.5.7",
 				"tslib": "^1.9.3",
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
 				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.11",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
-					"integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
 				}
 			}
 		},
 		"snyk-nuget-plugin": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.6.5.tgz",
-			"integrity": "sha512-3qIndzkxCxiaGvAwMkqChbChGdwhNePPyfi0WjhC/nJGwecqU3Fb/NeTW7lgyT+xoq/dFnzW0DgBJ4+AyNA2gA==",
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.11.2.tgz",
+			"integrity": "sha512-dNAwwFzrxI0gJh+3Eta7EFlz+jzXeTqXUwThaEASxCNNugV8gKsK/v+k0pQBsRPKvTLFlswB2D2Bt1E7YSOixA==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"jszip": "^3.1.5",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.14",
+				"snyk-paket-parser": "1.5.0",
+				"tslib": "^1.9.3",
 				"xml2js": "^0.4.17"
 			},
 			"dependencies": {
@@ -10904,42 +11347,45 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
 				}
+			}
+		},
+		"snyk-paket-parser": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/snyk-paket-parser/-/snyk-paket-parser-1.5.0.tgz",
+			"integrity": "sha512-1CYMPChJ9D9LBy3NLqHyv8TY7pR/LMISSr08LhfFw/FpfRZ+gTH8W6bbxCmybAYrOFNCqZkRprqOYDqZQFHipA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.9.3"
 			}
 		},
 		"snyk-php-plugin": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.5.1.tgz",
-			"integrity": "sha512-g5QSHBsRJ2O4cNxKC4zlWwnQYiSgQ77Y6QgGmo3ihPX3VLZrc1amaZIpPsNe1jwXirnGj2rvR5Xw+jDjbzvHFw==",
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.6.4.tgz",
+			"integrity": "sha512-FFQeimtbwq17nDUS0o0zuKgyjXSX7SpoC9iYTeKvxTXrmKf2QlxTtPvmMM4/hQxehEu1i40ow1Ozw0Ahxm8Dpw==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"lodash": "^4.17.5",
-				"path": "0.12.7"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"@snyk/composer-lockfile-parser": "1.0.3",
+				"tslib": "1.9.3"
 			}
 		},
 		"snyk-policy": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.13.1.tgz",
-			"integrity": "sha512-l9evS3Yk70xyvajjg+I6Ij7fr7gxpVRMZl0J1xNpWps/IVu4DSGih3aMmXi47VJozr4A/eFyj7R1lIr2GhqJCA==",
+			"version": "1.13.5",
+			"resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.13.5.tgz",
+			"integrity": "sha512-KI6GHt+Oj4fYKiCp7duhseUj5YhyL/zJOrrJg0u6r59Ux9w8gmkUYT92FHW27ihwuT6IPzdGNEuy06Yv2C9WaQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^3.1.0",
 				"email-validator": "^2.0.4",
-				"js-yaml": "^3.12.0",
+				"js-yaml": "^3.13.1",
 				"lodash.clonedeep": "^4.5.0",
-				"semver": "^5.6.0",
+				"semver": "^6.0.0",
 				"snyk-module": "^1.9.1",
 				"snyk-resolve": "^1.0.1",
 				"snyk-try-require": "^1.3.1",
@@ -10955,18 +11401,28 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"semver": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
 		},
 		"snyk-python-plugin": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.9.0.tgz",
-			"integrity": "sha512-zlyOHoCpmyVym9AwkboeepzEGrY3gHsM7eWP/nJ85TgCnQO5H5orKm3RL57PNbWRY+BnDmoQQ+udQgjym2+3sg==",
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.10.2.tgz",
+			"integrity": "sha512-dLswHfVI9Ax8+Ia/onhv1p9S5y+Ie/oELOfpfNApbb0BPTJ5k1c2CQ7WcgQ5/nDRMUOgoKn4VTObaAGmD5or9A==",
 			"dev": true,
 			"requires": {
 				"tmp": "0.0.33"
@@ -10994,9 +11450,9 @@
 			}
 		},
 		"snyk-resolve-deps": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.0.2.tgz",
-			"integrity": "sha512-nlw62wiWhGOTw3BD3jVIwrUkRR4iNxEkkO4Y/PWs8BsUWseGu1H6QgLesFXJb3qx7ANJ5UbUCJMgV+eL0Lf9cA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.0.3.tgz",
+			"integrity": "sha512-GP3VBrkz1iDDw2q8ftTqppHqzIAxmsUIoXR+FRWDKcipkKHXHJyUmtEo11QVT5fNRV0D0RCsssk2S5CTxTCu6A==",
 			"dev": true,
 			"requires": {
 				"ansicolors": "^0.3.2",
@@ -11028,10 +11484,39 @@
 			}
 		},
 		"snyk-sbt-plugin": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.0.0.tgz",
-			"integrity": "sha512-bOUqsQ1Lysnwfnvf4QQIBfC0M0ZVuhlshTKd7pNwgAJ41YEPJNrPEpzOePl/HfKtwilEEwHh5YHvjYGegEKx0A==",
-			"dev": true
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.6.1.tgz",
+			"integrity": "sha512-zWU14cm+cpamJ0CJdekTfgmv6ifdgVcapO6d27KTJThqRuR0arCqGPPyZa/Zl+jzhcK0dtRS4Ihk7g+d36SWIg==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.1.2",
+				"tmp": "^0.1.0",
+				"tree-kill": "^1.2.1",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"tmp": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+					"dev": true,
+					"requires": {
+						"rimraf": "^2.6.3"
+					}
+				},
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+					"dev": true
+				}
+			}
 		},
 		"snyk-tree": {
 			"version": "1.0.0",
@@ -11066,32 +11551,58 @@
 			}
 		},
 		"socks": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
-			"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.4",
-				"smart-buffer": "^1.0.13"
+				"ip": "^1.1.5",
+				"smart-buffer": "4.0.2"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^4.1.0",
-				"socks": "^1.1.10"
+				"agent-base": "~4.2.1",
+				"socks": "~2.3.2"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+					"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"es6-promise": {
+					"version": "4.2.8",
+					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+					"dev": true
+				},
+				"es6-promisify": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.0.3"
+					}
+				}
 			}
 		},
 		"sonic-boom": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.6.3.tgz",
-			"integrity": "sha512-TMhj6kDJk9LLzCTTL8+HPCfFn4MwkE4P6k2Up89Rz949+DSRw90V62upRKC99rJEOmu4E9ljH5Otu2JSRmx+bg==",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.5.tgz",
+			"integrity": "sha512-1pKrnAV6RfvntPnarY71tpthFTM3pWZWWQdghZY8ARjtDPGzG/inxqSuRwQY/7V1woUjfyxPb437zn4p5phgnQ==",
 			"dev": true,
 			"requires": {
-				"flatstr": "^1.0.8"
+				"flatstr": "^1.0.12"
 			}
 		},
 		"sort-keys": {
@@ -11129,11 +11640,12 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
-			"integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
 			"dev": true,
 			"requires": {
+				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
@@ -11282,32 +11794,6 @@
 			"requires": {
 				"inherits": "~2.0.1",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"stream-each": {
@@ -11331,32 +11817,6 @@
 				"readable-stream": "^2.3.6",
 				"to-arraybuffer": "^1.0.0",
 				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"stream-parser": {
@@ -11458,19 +11918,6 @@
 				}
 			}
 		},
-		"string.prototype.matchall": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz",
-			"integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.10.0",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"regexp.prototype.flags": "^1.2.0"
-			}
-		},
 		"string.prototype.padend": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
@@ -11483,9 +11930,9 @@
 			}
 		},
 		"string_decoder": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-			"integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -11510,22 +11957,22 @@
 			}
 		},
 		"strip-bom-buf": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
-			"integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
+			"integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
 			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
 			}
 		},
 		"strip-bom-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
-			"integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-4.0.0.tgz",
+			"integrity": "sha512-0ApK3iAkHv6WbgLICw/J4nhwHeDZsBxIIsOD+gHgZICL6SeJ0S9f/WZqemka9cjkTyMN5geId6e8U5WGFAn3cQ==",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "^2.0.0",
-				"strip-bom-buf": "^1.0.0"
+				"first-chunk-stream": "^3.0.0",
+				"strip-bom-buf": "^2.0.0"
 			}
 		},
 		"strip-eof": {
@@ -11591,31 +12038,65 @@
 			}
 		},
 		"svg-tag-names": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.1.tgz",
-			"integrity": "sha1-lkGynvcQJe4JTHBD983efZn71Qo="
-		},
-		"symbol-observable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-			"integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.2.tgz",
+			"integrity": "sha512-LIDOy8NRLGfJegTEnpizWA/ofg3Gyx58JgPEEjvATFciUJW9dHZ2aPTYY0Mn2rQYCeUGZElpHfu91OcWK0IMIw=="
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"table": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
-			"integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+			"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.6.1",
-				"lodash": "^4.17.11",
-				"slice-ansi": "2.0.0",
-				"string-width": "^2.1.1"
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
 			}
 		},
 		"tapable": {
@@ -11637,32 +12118,6 @@
 				"readable-stream": "^2.3.0",
 				"to-buffer": "^1.1.1",
 				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"temp-dir": {
@@ -11691,14 +12146,14 @@
 			}
 		},
 		"terser": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-			"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+			"integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.19.0",
+				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.10"
+				"source-map-support": "~0.5.12"
 			},
 			"dependencies": {
 				"source-map": {
@@ -11706,39 +12161,185 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"source-map-support": {
-					"version": "0.5.12",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
 				}
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
-			"integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
 			"dev": true,
 			"requires": {
-				"cacache": "^11.0.2",
-				"find-cache-dir": "^2.0.0",
+				"cacache": "^12.0.2",
+				"find-cache-dir": "^2.1.0",
+				"is-wsl": "^1.1.0",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.4.0",
+				"serialize-javascript": "^1.7.0",
 				"source-map": "^0.6.1",
-				"terser": "^3.16.1",
-				"webpack-sources": "^1.1.0",
-				"worker-farm": "^1.5.2"
+				"terser": "^4.1.2",
+				"webpack-sources": "^1.4.0",
+				"worker-farm": "^1.7.0"
 			},
 			"dependencies": {
+				"cacache": {
+					"version": "12.0.2",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
+					"integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"infer-owner": "^1.0.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
+					}
+				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+					"dev": true,
+					"requires": {
+						"pify": "^4.0.1",
+						"semver": "^5.6.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+					"dev": true,
+					"requires": {
+						"find-up": "^3.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"dev": true
 				}
 			}
@@ -11796,32 +12397,6 @@
 			"requires": {
 				"readable-stream": "~2.3.6",
 				"xtend": "~4.0.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"thunkify": {
@@ -11886,6 +12461,12 @@
 				}
 			}
 		},
+		"to-readable-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"dev": true
+		},
 		"to-regex": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -11919,10 +12500,16 @@
 				"repeat-string": "^1.6.1"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
 		"toml": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-			"integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
 			"dev": true
 		},
 		"tosource": {
@@ -11932,19 +12519,12 @@
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -11961,6 +12541,12 @@
 			"integrity": "sha1-0EsigOTHkqWBVCnve4tgxkyczDQ=",
 			"dev": true
 		},
+		"tree-kill": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
+			"integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+			"dev": true
+		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -11968,16 +12554,16 @@
 			"dev": true
 		},
 		"ts-loader": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.3.tgz",
-			"integrity": "sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.0.4.tgz",
+			"integrity": "sha512-p2zJYe7OtwR+49kv4gs7v4dMrfYD1IPpOtqiSPCbe8oR+4zEBtdHwzM7A7M91F+suReqgzZrlClk4LRSSp882g==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
 				"loader-utils": "^1.0.2",
-				"micromatch": "^3.1.4",
-				"semver": "^5.0.1"
+				"micromatch": "^4.0.0",
+				"semver": "^6.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -11987,6 +12573,15 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
 					}
 				},
 				"chalk": {
@@ -12000,6 +12595,37 @@
 						"supports-color": "^5.3.0"
 					}
 				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -12007,6 +12633,15 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
 					}
 				}
 			}
@@ -12018,9 +12653,9 @@
 			"dev": true
 		},
 		"tsutils": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.9.1.tgz",
-			"integrity": "sha512-hrxVtLtPqQr//p8/msPT1X1UYXUjizqSit5d9AQ5k38TcV38NyecL5xODNxa73cLe/5sdiJ+w1FqzDhRBA/anA==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
+			"integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -12045,6 +12680,12 @@
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
+		"type": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+			"integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+			"dev": true
+		},
 		"type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -12053,6 +12694,12 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
+		"type-fest": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+			"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+			"dev": true
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -12060,36 +12707,10 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.3.4000",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-			"integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
-		},
-		"undefsafe": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
-			"integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.2.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
 		},
 		"underscore": {
 			"version": "1.9.1",
@@ -12107,38 +12728,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"unique-filename": {
@@ -12151,9 +12749,9 @@
 			}
 		},
 		"unique-slug": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
@@ -12227,9 +12825,9 @@
 			"dev": true
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
 			"dev": true
 		},
 		"update-notifier": {
@@ -12338,9 +12936,9 @@
 			}
 		},
 		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+			"integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
@@ -12368,9 +12966,9 @@
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-			"integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
 			"dev": true
 		},
 		"validate-npm-package-license": {
@@ -12394,13 +12992,10 @@
 			}
 		},
 		"vm-browserify": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
-			"requires": {
-				"indexof": "0.0.1"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+			"dev": true
 		},
 		"vscode-languageserver-types": {
 			"version": "3.14.0",
@@ -12427,9 +13022,9 @@
 			}
 		},
 		"watchpack": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-			"integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^2.0.2",
@@ -12447,46 +13042,59 @@
 			}
 		},
 		"web-ext": {
-			"version": "2.9.3",
-			"resolved": "https://registry.npmjs.org/web-ext/-/web-ext-2.9.3.tgz",
-			"integrity": "sha512-aZnlxuYOMUUBS5C8NBhhAj7T0ouJexlW5Cx5ObtOheoguG3fqXUl+KTY19L1Am/bJoyHC8otGTgew9Z0WHeTtg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/web-ext/-/web-ext-3.1.1.tgz",
+			"integrity": "sha512-snTfhuxoplm8QAlv+CwOaF0XSaycDUmxsrLfi4NtZRvZ6J79+ijOu9HyTXP0rd1zT3uagWYOBc3ol/ZOsf1LQQ==",
 			"dev": true,
 			"requires": {
+				"@babel/polyfill": "7.4.4",
+				"@babel/runtime": "7.4.5",
 				"@cliqz-oss/firefox-client": "0.3.1",
 				"@cliqz-oss/node-firefox-connect": "1.2.1",
-				"adbkit": "2.11.0",
-				"addons-linter": "1.4.1",
-				"babel-polyfill": "6.26.0",
-				"babel-runtime": "6.26.0",
+				"adbkit": "2.11.1",
+				"addons-linter": "1.10.0",
 				"bunyan": "1.8.12",
-				"camelcase": "4.1.0",
-				"debounce": "1.1.0",
-				"decamelize": "2.0.0",
+				"camelcase": "5.3.1",
+				"debounce": "1.2.0",
+				"decamelize": "3.2.0",
 				"es6-error": "4.1.1",
-				"es6-promisify": "5.0.0",
 				"event-to-promise": "0.8.0",
 				"firefox-profile": "1.2.0",
-				"fx-runner": "1.0.9",
-				"git-rev-sync": "1.9.1",
+				"fx-runner": "1.0.11",
+				"git-rev-sync": "1.12.0",
 				"mkdirp": "0.5.1",
-				"multimatch": "2.1.0",
+				"multimatch": "4.0.0",
 				"mz": "2.7.0",
-				"node-notifier": "5.2.1",
-				"opn": "5.3.0",
+				"node-notifier": "5.4.0",
+				"opn": "5.5.0",
 				"parse-json": "4.0.0",
-				"regenerator-runtime": "0.11.1",
-				"require-uncached": "1.0.3",
+				"require-uncached": "2.0.0",
 				"sign-addon": "0.3.1",
-				"source-map-support": "0.5.3",
+				"source-map-support": "0.5.12",
 				"stream-to-promise": "2.2.0",
-				"strip-json-comments": "2.0.1",
-				"tmp": "0.0.33",
-				"update-notifier": "2.3.0",
-				"watchpack": "1.5.0",
-				"yargs": "6.6.0",
+				"strip-json-comments": "3.0.1",
+				"tmp": "0.1.0",
+				"update-notifier": "3.0.1",
+				"watchpack": "1.6.0",
+				"yargs": "13.2.4",
 				"zip-dir": "1.0.2"
 			},
 			"dependencies": {
+				"ansi-align": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+					"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12496,10 +13104,44 @@
 						"color-convert": "^1.9.0"
 					}
 				},
+				"array-differ": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+					"integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"dev": true
+				},
+				"boxen": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+					"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+					"dev": true,
+					"requires": {
+						"ansi-align": "^3.0.0",
+						"camelcase": "^5.3.1",
+						"chalk": "^2.4.2",
+						"cli-boxes": "^2.2.0",
+						"string-width": "^3.0.0",
+						"term-size": "^1.2.0",
+						"type-fest": "^0.3.0",
+						"widest-line": "^2.0.0"
+					}
+				},
 				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"chalk": {
@@ -12513,63 +13155,249 @@
 						"supports-color": "^5.3.0"
 					}
 				},
+				"ci-info": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"dev": true
+				},
+				"cli-boxes": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+					"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+					"dev": true
+				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"configstore": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+					"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
 					}
 				},
 				"decamelize": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-					"integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
+					"integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
 					"dev": true,
 					"requires": {
-						"xregexp": "4.0.0"
+						"xregexp": "^4.2.4"
 					}
 				},
-				"is-fullwidth-code-point": {
+				"execa": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "9.6.0",
+					"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+					"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "^0.14.0",
+						"@szmarczak/http-timer": "^1.1.2",
+						"cacheable-request": "^6.0.0",
+						"decompress-response": "^3.3.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^4.1.0",
+						"lowercase-keys": "^1.0.1",
+						"mimic-response": "^1.0.1",
+						"p-cancelable": "^1.0.0",
+						"to-readable-stream": "^1.0.0",
+						"url-parse-lax": "^3.0.0"
+					}
+				},
+				"has-yarn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+					"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"is-ci": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+					"dev": true,
+					"requires": {
+						"ci-info": "^2.0.0"
+					}
+				},
+				"is-npm": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+					"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+					"dev": true
+				},
+				"latest-version": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+					"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+					"dev": true,
+					"requires": {
+						"package-json": "^6.3.0"
+					}
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
 				},
 				"multimatch": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-					"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+					"integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
 					"dev": true,
 					"requires": {
-						"array-differ": "^1.0.0",
-						"array-union": "^1.0.1",
-						"arrify": "^1.0.0",
-						"minimatch": "^3.0.0"
+						"@types/minimatch": "^3.0.3",
+						"array-differ": "^3.0.0",
+						"array-union": "^2.1.0",
+						"arrify": "^2.0.1",
+						"minimatch": "^3.0.4"
 					}
 				},
 				"opn": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-					"integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+					"integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
 					"dev": true,
 					"requires": {
 						"is-wsl": "^1.1.0"
 					}
 				},
 				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 					"dev": true,
 					"requires": {
-						"lcid": "^1.0.0"
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"package-json": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+					"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+					"dev": true,
+					"requires": {
+						"got": "^9.6.0",
+						"registry-auth-token": "^4.0.0",
+						"registry-url": "^5.0.0",
+						"semver": "^6.2.0"
 					}
 				},
 				"parse-json": {
@@ -12582,16 +13410,90 @@
 						"json-parse-better-errors": "^1.0.1"
 					}
 				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"prepend-http": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+					"dev": true
+				},
+				"registry-auth-token": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+					"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"rc": "^1.2.8",
+						"safe-buffer": "^5.0.1"
 					}
+				},
+				"registry-url": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+					"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+					"dev": true,
+					"requires": {
+						"rc": "^1.2.8"
+					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.12",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
@@ -12602,62 +13504,105 @@
 						"has-flag": "^3.0.0"
 					}
 				},
-				"update-notifier": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-					"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+				"tmp": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+					"integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
 					"dev": true,
 					"requires": {
-						"boxen": "^1.2.1",
+						"rimraf": "^2.6.3"
+					}
+				},
+				"type-fest": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"dev": true
+				},
+				"update-notifier": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+					"integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+					"dev": true,
+					"requires": {
+						"boxen": "^3.0.0",
 						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
+						"configstore": "^4.0.0",
+						"has-yarn": "^2.1.0",
 						"import-lazy": "^2.1.0",
+						"is-ci": "^2.0.0",
 						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
+						"is-npm": "^3.0.0",
+						"is-yarn-global": "^0.3.0",
+						"latest-version": "^5.0.0",
 						"semver-diff": "^2.0.0",
 						"xdg-basedir": "^3.0.0"
 					}
 				},
-				"which-module": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-					"dev": true
+				"url-parse-lax": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+					"dev": true,
+					"requires": {
+						"prepend-http": "^2.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
 				},
 				"xregexp": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+					"integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "^7.2.0"
+					}
+				},
+				"y18n": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-					"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+					"version": "13.2.4",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^4.2.0"
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
 					},
 					"dependencies": {
-						"camelcase": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-							"dev": true
-						},
 						"decamelize": {
 							"version": "1.2.0",
 							"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -12665,33 +13610,16 @@
 							"dev": true
 						}
 					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^3.0.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-							"dev": true
-						}
-					}
 				}
 			}
 		},
 		"web-ext-submit": {
-			"version": "2.9.3",
-			"resolved": "https://registry.npmjs.org/web-ext-submit/-/web-ext-submit-2.9.3.tgz",
-			"integrity": "sha512-yeMRnzUrv0qZcGC8jKaFbHbywWnKjfGdv5refFVcxbeK+RFx+pIHIO7/6lrkzScnT/Y0LxA17sIRr3PV+ZY8iA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/web-ext-submit/-/web-ext-submit-3.1.1.tgz",
+			"integrity": "sha512-rQoyAMcwWY5/ywkg5cfOe33/zZQtcMcU4mq1eA39ZJb2Kf0Yxkx1/TZDey5ZpU0p1r1JWfJdJM8fu6OkE/1iRA==",
 			"dev": true,
 			"requires": {
-				"web-ext": "^2.9.3"
+				"web-ext": "^3.1.1"
 			}
 		},
 		"webext-content-script-ping": {
@@ -12718,17 +13646,16 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.30.0.tgz",
-			"integrity": "sha512-4hgvO2YbAFUhyTdlR4FNyt2+YaYBYHavyzjCMbZzgglo02rlKi/pcsEzwCuCpsn1ryzIl1cq/u8ArIKu8JBYMg==",
+			"version": "4.38.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
+			"integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/wasm-edit": "1.8.5",
 				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.0.5",
-				"acorn-dynamic-import": "^4.0.0",
+				"acorn": "^6.2.0",
 				"ajv": "^6.1.0",
 				"ajv-keywords": "^3.1.0",
 				"chrome-trace-event": "^1.0.0",
@@ -12747,27 +13674,41 @@
 				"terser-webpack-plugin": "^1.1.0",
 				"watchpack": "^1.5.0",
 				"webpack-sources": "^1.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"dev": true
+				}
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
-			"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
+			"integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"cross-spawn": "^6.0.5",
-				"enhanced-resolve": "^4.1.0",
-				"findup-sync": "^2.0.0",
-				"global-modules": "^1.0.0",
-				"import-local": "^2.0.0",
-				"interpret": "^1.1.0",
-				"loader-utils": "^1.1.0",
-				"supports-color": "^5.5.0",
-				"v8-compile-cache": "^2.0.2",
-				"yargs": "^12.0.5"
+				"chalk": "2.4.2",
+				"cross-spawn": "6.0.5",
+				"enhanced-resolve": "4.1.0",
+				"findup-sync": "3.0.0",
+				"global-modules": "2.0.0",
+				"import-local": "2.0.0",
+				"interpret": "1.2.0",
+				"loader-utils": "1.2.3",
+				"supports-color": "6.1.0",
+				"v8-compile-cache": "2.0.3",
+				"yargs": "13.2.4"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12792,6 +13733,28 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
 					}
 				},
 				"execa": {
@@ -12817,6 +13780,12 @@
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
 				},
 				"get-stream": {
 					"version": "4.1.0",
@@ -12910,39 +13879,81 @@
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
 				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
 				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.2.4",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.0"
 					}
 				},
 				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -12962,9 +13973,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.1.tgz",
+			"integrity": "sha512-XSz38193PTo/1csJabKaV4b53uRVotlMgqJXm3s3eje0Bu6gQTxYDqpD38CmQfDBA+gN+QqaGjasuC8I/7eW3Q==",
 			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
@@ -13032,20 +14043,46 @@
 				"string-width": "^2.1.1"
 			}
 		},
-		"win-release": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
-			"dev": true,
-			"requires": {
-				"semver": "^5.0.1"
-			}
-		},
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
 			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
 			"dev": true
+		},
+		"windows-release": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+			"dev": true,
+			"requires": {
+				"execa": "^1.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
 		},
 		"winreg": {
 			"version": "0.0.12",
@@ -13059,9 +14096,9 @@
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 			"dev": true,
 			"requires": {
 				"errno": "~0.1.7"
@@ -13193,15 +14230,9 @@
 			"dev": true
 		},
 		"xmlchars": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-			"integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
-		},
-		"xmldom": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-			"dev": true
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
+			"integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w=="
 		},
 		"xo": {
 			"version": "0.24.0",
@@ -13243,6 +14274,39 @@
 				"xo-init": "^0.7.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -13260,6 +14324,100 @@
 						"quick-lru": "^1.0.0"
 					}
 				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
+				"eslint": {
+					"version": "5.16.0",
+					"resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
+					"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"ajv": "^6.9.1",
+						"chalk": "^2.1.0",
+						"cross-spawn": "^6.0.5",
+						"debug": "^4.0.1",
+						"doctrine": "^3.0.0",
+						"eslint-scope": "^4.0.3",
+						"eslint-utils": "^1.3.1",
+						"eslint-visitor-keys": "^1.0.0",
+						"espree": "^5.0.1",
+						"esquery": "^1.0.1",
+						"esutils": "^2.0.2",
+						"file-entry-cache": "^5.0.1",
+						"functional-red-black-tree": "^1.0.1",
+						"glob": "^7.1.2",
+						"globals": "^11.7.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.0.0",
+						"imurmurhash": "^0.1.4",
+						"inquirer": "^6.2.2",
+						"js-yaml": "^3.13.0",
+						"json-stable-stringify-without-jsonify": "^1.0.1",
+						"levn": "^0.3.0",
+						"lodash": "^4.17.11",
+						"minimatch": "^3.0.4",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"optionator": "^0.8.2",
+						"path-is-inside": "^1.0.2",
+						"progress": "^2.0.0",
+						"regexpp": "^2.0.1",
+						"semver": "^5.5.1",
+						"strip-ansi": "^4.0.0",
+						"strip-json-comments": "^2.0.1",
+						"table": "^5.2.3",
+						"text-table": "^0.2.0"
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"espree": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+					"dev": true,
+					"requires": {
+						"acorn": "^6.0.7",
+						"acorn-jsx": "^5.0.0",
+						"eslint-visitor-keys": "^1.0.0"
+					}
+				},
+				"file-entry-cache": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+					"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^2.0.1"
+					}
+				},
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -13267,6 +14425,17 @@
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
+					}
+				},
+				"flat-cache": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+					"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+					"dev": true,
+					"requires": {
+						"flatted": "^2.0.0",
+						"rimraf": "2.6.3",
+						"write": "1.0.3"
 					}
 				},
 				"get-stdin": {
@@ -13378,6 +14547,15 @@
 						"strip-indent": "^2.0.0"
 					}
 				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
 				"strip-bom": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -13390,11 +14568,29 @@
 					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
 					"dev": true
 				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
 				"trim-newlines": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
 					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 					"dev": true
+				},
+				"write": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+					"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+					"dev": true,
+					"requires": {
+						"mkdirp": "^0.5.1"
+					}
 				},
 				"yargs-parser": {
 					"version": "10.1.0",
@@ -13537,9 +14733,9 @@
 			"dev": true
 		},
 		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"y18n": {
@@ -13603,9 +14799,9 @@
 			}
 		},
 		"yauzl": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-			"integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"dev": true,
 			"requires": {
 				"buffer-crc32": "~0.2.3",
@@ -13658,32 +14854,6 @@
 				"compress-commons": "^1.2.0",
 				"lodash": "^4.8.0",
 				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
 			}
 		},
 		"@types/chrome": {
-			"version": "0.0.86",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.86.tgz",
-			"integrity": "sha512-7ehebPf/5IR64SYdD2Vig0q0oUCNbWMQ29kASlNJaHVVtA5/J/DnrxnYVPCID70o7LgHdYsav6I4/XdqAxjTLQ==",
+			"version": "0.0.88",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.88.tgz",
+			"integrity": "sha512-JBsIrBZ2adJhlXvJ+1j0xLbcfOfwee/WAg7Lp2NE+Wf3m0vXMJFWv/PPjqNk5ZUXDeY/qDxPHe+PUjxnl8HWFg==",
 			"requires": {
 				"@types/filesystem": "*"
 			}
@@ -257,6 +257,11 @@
 			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
 			"integrity": "sha1-wFTor02d11205jq8dviFFocU1LM="
 		},
+		"@types/firefox-webext-browser": {
+			"version": "67.0.2",
+			"resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-67.0.2.tgz",
+			"integrity": "sha512-tXR5THtH5Fqwfmi4y/2dTxCTebqHsKCH2bif/VdE5CPcB/S5x5fu+N+wBuMENzN41agovHMU/LQbtWNV+Aux+w=="
+		},
 		"@types/json-schema": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
@@ -282,9 +287,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.8.24",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
-			"integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
+			"version": "16.8.25",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.25.tgz",
+			"integrity": "sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -2405,25 +2410,29 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2433,13 +2442,15 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2449,37 +2460,43 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2488,25 +2505,29 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2515,13 +2536,15 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2537,7 +2560,8 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2551,13 +2575,15 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2566,7 +2592,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2575,7 +2602,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2585,19 +2613,22 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2606,13 +2637,15 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2621,13 +2654,15 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2637,7 +2672,8 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2646,7 +2682,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2655,13 +2692,15 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2672,7 +2711,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2690,7 +2730,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2700,13 +2741,15 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2716,7 +2759,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2728,19 +2772,22 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2749,19 +2796,22 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2771,19 +2821,22 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2795,7 +2848,8 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
 								}
@@ -2803,7 +2857,8 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2818,7 +2873,8 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2827,43 +2883,50 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2874,7 +2937,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2883,7 +2947,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2892,13 +2957,15 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2913,13 +2980,15 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -2928,13 +2997,15 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"dev": true,
 							"optional": true
 						}
@@ -3300,6 +3371,14 @@
 			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
 			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
 			"dev": true
+		},
+		"content-scripts-register-polyfill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/content-scripts-register-polyfill/-/content-scripts-register-polyfill-1.0.0.tgz",
+			"integrity": "sha512-DiHscMTyL5evEg6C8GSkkd5Kfkma726zxqIt+zv6L2W/gVqYOUZUw2F27BpAUp9nQZnIrky5Gx1eYA9Fw4+aeA==",
+			"requires": {
+				"@types/firefox-webext-browser": "^67.0.2"
+			}
 		},
 		"copy-concurrently": {
 			"version": "1.0.5",
@@ -13622,23 +13701,57 @@
 				"web-ext": "^3.1.1"
 			}
 		},
-		"webext-content-script-ping": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/webext-content-script-ping/-/webext-content-script-ping-2.0.1.tgz",
-			"integrity": "sha512-37oaeT0GwwkIC8JUD5aToOr0ncdoml/kjZdsn5ckyKyZqpNQHYxhP3NhnqsSx25LpxGfJm8er/IPv9pzCLcfUA=="
+		"webext-additional-permissions": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-0.1.0.tgz",
+			"integrity": "sha512-eA1o6BdRbpU5ClL6GcmwhGtVVzNTbQSqX9esakpurWYVt9ykpGQ1ZNe5l30Yt19GW0eRC8VdroOeJSumP5cMpQ==",
+			"requires": {
+				"@types/chrome": "0.0.86"
+			},
+			"dependencies": {
+				"@types/chrome": {
+					"version": "0.0.86",
+					"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.86.tgz",
+					"integrity": "sha512-7ehebPf/5IR64SYdD2Vig0q0oUCNbWMQ29kASlNJaHVVtA5/J/DnrxnYVPCID70o7LgHdYsav6I4/XdqAxjTLQ==",
+					"requires": {
+						"@types/filesystem": "*"
+					}
+				}
+			}
 		},
 		"webext-domain-permission-toggle": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/webext-domain-permission-toggle/-/webext-domain-permission-toggle-0.1.0.tgz",
-			"integrity": "sha512-zPwVKYa5EiH0htXedmoAWUaMqU7pOr+4dlzFyGVM64Q0jLVo3V8AVcYOVDKtY+c9qOkhtoSUCGcXCnbs5u8eNg=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/webext-domain-permission-toggle/-/webext-domain-permission-toggle-1.0.0.tgz",
+			"integrity": "sha512-K6RAOYtVCMAmqjQPopMbGOIoxpFU05ERGgaLkUNvFCdpPsXLB5y4m1+Cq1dezyfx6FU0lLEqxoL/5/49+EY5zA==",
+			"requires": {
+				"webext-additional-permissions": "^0.1.0"
+			}
 		},
 		"webext-dynamic-content-scripts": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-5.0.2.tgz",
-			"integrity": "sha512-Y2FMB5Rz29UzQ7eUi9lcNUDeAAhvDDY7Ga1UcCbaHmu6ro3tJpJlzgk7HWaxOBuCtsfFyhZPmitC59n6PGlBFA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/webext-dynamic-content-scripts/-/webext-dynamic-content-scripts-6.0.2.tgz",
+			"integrity": "sha512-8X2yqLPjP8jLMdCMLz/QXVkipt9H9J1kitUoG8S9O03urQnsRvduXnkmfpTZnNajr0q2mn5DN6ReXMZOp87vUw==",
 			"requires": {
-				"webext-content-script-ping": "^2.0.1"
+				"@types/chrome": "0.0.86",
+				"content-scripts-register-polyfill": "^1.0.0",
+				"webext-additional-permissions": "^0.1.0",
+				"webext-permissions-events-polyfill": "^1.0.1"
+			},
+			"dependencies": {
+				"@types/chrome": {
+					"version": "0.0.86",
+					"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.86.tgz",
+					"integrity": "sha512-7ehebPf/5IR64SYdD2Vig0q0oUCNbWMQ29kASlNJaHVVtA5/J/DnrxnYVPCID70o7LgHdYsav6I4/XdqAxjTLQ==",
+					"requires": {
+						"@types/filesystem": "*"
+					}
+				}
 			}
+		},
+		"webext-permissions-events-polyfill": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/webext-permissions-events-polyfill/-/webext-permissions-events-polyfill-1.0.1.tgz",
+			"integrity": "sha512-dPsU7KtDn+OG+mPy0LLc9UhMXdVeQ8ywD5kK1GFtvceur4IWOnpI5D4uTjMPrKm8+re/8cbHKwVjnviIA9wZ3Q=="
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
@@ -13646,34 +13759,34 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
-			"integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
+			"version": "4.39.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.1.tgz",
+			"integrity": "sha512-/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==",
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/wasm-edit": "1.8.5",
 				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.2.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
+				"acorn": "^6.2.1",
+				"ajv": "^6.10.2",
+				"ajv-keywords": "^3.4.1",
+				"chrome-trace-event": "^1.0.2",
 				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
+				"eslint-scope": "^4.0.3",
 				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
+				"loader-runner": "^2.4.0",
+				"loader-utils": "^1.2.3",
+				"memory-fs": "^0.4.1",
+				"micromatch": "^3.1.10",
+				"mkdirp": "^0.5.1",
+				"neo-async": "^2.6.1",
+				"node-libs-browser": "^2.2.1",
 				"schema-utils": "^1.0.0",
-				"tapable": "^1.1.0",
-				"terser-webpack-plugin": "^1.1.0",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
+				"tapable": "^1.1.3",
+				"terser-webpack-plugin": "^1.4.1",
+				"watchpack": "^1.6.0",
+				"webpack-sources": "^1.4.1"
 			},
 			"dependencies": {
 				"acorn": {
@@ -13681,6 +13794,28 @@
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
 					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
 					"dev": true
+				},
+				"ajv": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^2.0.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"eslint-scope": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.1.0",
+						"estraverse": "^4.1.1"
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
 		"update-version": "dot-json distribution/manifest.json version $TRAVIS_TAG"
 	},
 	"dependencies": {
-		"@types/chrome": "0.0.86",
+		"@types/chrome": "0.0.88",
 		"dom-chef": "^3.6.1",
 		"element-ready": "^4.1.0",
 		"select-dom": "^5.1.0",
-		"webext-domain-permission-toggle": "^0.1.0",
-		"webext-dynamic-content-scripts": "^5.0.2"
+		"webext-domain-permission-toggle": "^1.0.0",
+		"webext-dynamic-content-scripts": "^6.0.2"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.4.0",
-		"@types/react": "^16.8.24",
+		"@types/react": "^16.8.25",
 		"@typescript-eslint/eslint-plugin": "^1.13.0",
 		"@typescript-eslint/parser": "^1.13.0",
 		"chrome-webstore-upload-cli": "^1.2.0",
@@ -33,7 +33,7 @@
 		"ts-loader": "^6.0.4",
 		"typescript": "^3.5.3",
 		"web-ext-submit": "^3.1.1",
-		"webpack": "^4.38.0",
+		"webpack": "^4.39.1",
 		"webpack-cli": "^3.3.6",
 		"xo": "^0.24.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"private": true,
 	"scripts": {
 		"test": "npm run build && xo",
 		"build": "webpack --mode=production",
@@ -8,22 +9,32 @@
 		"release": "run-s build update-version release:*",
 		"update-version": "dot-json distribution/manifest.json version $TRAVIS_TAG"
 	},
+	"dependencies": {
+		"@types/chrome": "0.0.86",
+		"dom-chef": "^3.6.1",
+		"element-ready": "^4.1.0",
+		"select-dom": "^5.1.0",
+		"webext-domain-permission-toggle": "^0.1.0",
+		"webext-dynamic-content-scripts": "^5.0.2"
+	},
 	"devDependencies": {
-		"@sindresorhus/tsconfig": "^0.3.0",
-		"@types/react": "^16.8.15",
-		"@typescript-eslint/eslint-plugin": "^1.5.0",
-		"chrome-webstore-upload-cli": "^1.1.1",
-		"copy-webpack-plugin": "^5.0.2",
+		"@sindresorhus/tsconfig": "^0.4.0",
+		"@types/react": "^16.8.24",
+		"@typescript-eslint/eslint-plugin": "^1.13.0",
+		"@typescript-eslint/parser": "^1.13.0",
+		"chrome-webstore-upload-cli": "^1.2.0",
+		"copy-webpack-plugin": "^5.0.4",
 		"dot-json": "^1.1.0",
-		"eslint-config-xo-typescript": "^0.9.0",
-		"npm-run-all": "^4.1.3",
+		"eslint": "^6.1.0",
+		"eslint-config-xo-typescript": "^0.15.0",
+		"npm-run-all": "^4.1.5",
 		"size-plugin": "^1.2.0",
-		"terser-webpack-plugin": "^1.2.3",
-		"ts-loader": "^5.3.3",
-		"typescript": "^3.3.4000",
-		"web-ext-submit": "^2.9.3",
-		"webpack": "^4.30.0",
-		"webpack-cli": "^3.3.0",
+		"terser-webpack-plugin": "^1.4.1",
+		"ts-loader": "^6.0.4",
+		"typescript": "^3.5.3",
+		"web-ext-submit": "^3.1.1",
+		"webpack": "^4.38.0",
+		"webpack-cli": "^3.3.6",
 		"xo": "^0.24.0"
 	},
 	"xo": {
@@ -52,13 +63,5 @@
 				}
 			}
 		]
-	},
-	"dependencies": {
-		"@types/chrome": "0.0.81",
-		"dom-chef": "^3.6.0",
-		"element-ready": "^3.1.0",
-		"select-dom": "^5.0.1",
-		"webext-domain-permission-toggle": "^0.1.0",
-		"webext-dynamic-content-scripts": "^5.0.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"element-ready": "^4.1.0",
 		"select-dom": "^5.1.0",
 		"webext-domain-permission-toggle": "^1.0.0",
-		"webext-dynamic-content-scripts": "^6.0.2"
+		"webext-dynamic-content-scripts": "^6.0.3-0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.4.0",

--- a/source/api.ts
+++ b/source/api.ts
@@ -24,11 +24,13 @@ export const defaults = {
 };
 
 export const storage = {
-	get: (): Promise<typeof defaults> => new Promise(resolve => {
-		// Drop `as` when `.get` rightfully resolves to `typeof defaults` instead of `AnyObject`
-		chrome.storage.sync.get(defaults, options => resolve(options as typeof defaults));
-	}),
-	set: (object: typeof defaults) => {
+	async get(): Promise<typeof defaults> {
+		return new Promise(resolve => {
+			// Drop `as` when `.get` rightfully resolves to `typeof defaults` instead of `AnyObject`
+			chrome.storage.sync.get(defaults, options => resolve(options as typeof defaults));
+		});
+	},
+	set(object: typeof defaults) {
 		chrome.storage.sync.set(object);
 	}
 };

--- a/source/background.ts
+++ b/source/background.ts
@@ -1,6 +1,5 @@
-import {addContextMenu} from 'webext-domain-permission-toggle';
-import {addToFutureTabs} from 'webext-dynamic-content-scripts';
+import 'webext-dynamic-content-scripts';
+import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 
 // GitHub Enterprise support
-addToFutureTabs();
-addContextMenu();
+addDomainPermissionToggle();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
 		"target": "esnext",
-		"module": "es2015",
-		"declaration": false
+		"declaration": false,
+		"esModuleInterop": true
 	},
 	"include": [
 		"source"


### PR DESCRIPTION
- Update `element-ready` to `4.1.0` from `3.1.0` to stop rAF from running after page load ([context](https://github.com/sindresorhus/refined-github/issues/2290#issuecomment-516846928)).
- Updated rest of the packages too.
- Add `"private": true` to `package.json` to avoid warning message while using `npm install`.
- Copy over `tsconfig.json` from RGH.