### PR TITLE
update SizePlugin version & add support for bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1429,6 +1429,24 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
+		"axios": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"dev": true
+				}
+			}
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -2086,7 +2104,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -2107,12 +2126,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -2127,17 +2148,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -2254,7 +2278,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -2266,6 +2291,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -2280,6 +2306,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -2287,12 +2314,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -2311,6 +2340,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -2391,7 +2421,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -2403,6 +2434,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -2488,7 +2520,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -2524,6 +2557,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -2543,6 +2577,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -2586,12 +2621,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				},
@@ -2648,6 +2685,12 @@
 				"recursive-readdir": "^2.0.0",
 				"yazl": "^2.3.1"
 			}
+		},
+		"ci-env": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.10.0.tgz",
+			"integrity": "sha512-kXGriGO7hW/uxDviPtUUehSG301RudEHUXNhAHeM5JM7iOSb6+tpXh+YqhcfxdCECvtfMNq0J7laOxAV3NsDng==",
+			"dev": true
 		},
 		"ci-info": {
 			"version": "1.6.0",
@@ -5657,6 +5700,32 @@
 				}
 			}
 		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"dev": true,
+			"requires": {
+				"debug": "=3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -6149,9 +6218,9 @@
 			"dev": true
 		},
 		"gzip-size": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",
-			"integrity": "sha512-wfSnvypBDRW94v5W3ckvvz/zFUNdJ81VgOP6tE4bPpRUcc0wGqU+y0eZjJEvKxwubJFix6P84sE8M51YWLT7rQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+			"integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
 			"dev": true,
 			"requires": {
 				"duplexer": "^0.1.1",
@@ -9323,9 +9392,9 @@
 			}
 		},
 		"pretty-bytes": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
-			"integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
 			"dev": true
 		},
 		"probe-image-size": {
@@ -10366,17 +10435,19 @@
 			"dev": true
 		},
 		"size-plugin": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-1.2.0.tgz",
-			"integrity": "sha512-lgB1vsrDM17fhmUrsS5vP1Tg+R57+AEMhms2B6iBuI3EHWVNQv3TANqixzwDOcMV5azX6DIqOaPu2+6CWw7b3Q==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-2.0.0.tgz",
+			"integrity": "sha512-0ww2iVo8RjZtafpuJocP7P+ueYLCepEwvw5kmcNQUqdYmjmpOre179PockiFapm0CinTNGEHsE8KI7OFZLHRUg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"axios": "^0.19.0",
+				"chalk": "^2.4.2",
+				"ci-env": "^1.9.0",
 				"escape-string-regexp": "^1.0.5",
-				"glob": "^7.1.2",
-				"gzip-size": "^5.0.0",
+				"glob": "^7.1.4",
+				"gzip-size": "^5.1.1",
 				"minimatch": "^3.0.4",
-				"pretty-bytes": "^5.1.0",
+				"pretty-bytes": "^5.3.0",
 				"util.promisify": "^1.0.0"
 			},
 			"dependencies": {
@@ -10398,6 +10469,20 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"supports-color": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"dot-json": "^1.1.0",
 		"eslint-config-xo-typescript": "^0.9.0",
 		"npm-run-all": "^4.1.3",
-		"size-plugin": "^1.2.0",
+		"size-plugin": "^2.0.0",
 		"terser-webpack-plugin": "^1.2.3",
 		"ts-loader": "^5.3.3",
 		"typescript": "^3.3.4000",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = (env, argv) => ({
 		}]
 	},
 	plugins: [
-		new SizePlugin(),
+		new SizePlugin({publish:true}),
 		new CopyWebpackPlugin([{
 			from: '**',
 			context: 'source',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = (env, argv) => ({
 		}]
 	},
 	plugins: [
-		new SizePlugin({ publish: true }),
+		new SizePlugin({publish: true}),
 		new CopyWebpackPlugin([{
 			from: '**',
 			context: 'source',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = (env, argv) => ({
 		}]
 	},
 	plugins: [
-		new SizePlugin({publish:true}),
+		new SizePlugin({ publish: true }),
 		new CopyWebpackPlugin([{
 			from: '**',
 			context: 'source',


### PR DESCRIPTION
👋
I noticed `hide-files-on-github` is using [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) .

I have created a [bot](https://github.com/kuldeepkeshwar/size-plugin-bot), which works with  [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) and comments the sizes of the assets and the changes since the last build into the relevant PR

I have done the required configuration in pr (updating `size-plugin@2.0.0` & turn on `publish` flag)

Action item: 
- install [bot](https://github.com/kuldeepkeshwar/size-plugin-bot)