### PR TITLE
Fix Firefox FOUC

### DIFF
--- a/source/hide-files-on-github.css
+++ b/source/hide-files-on-github.css
@@ -19,10 +19,12 @@
 	padding-left: 5px !important;
 	padding-right: 10px !important;
 	white-space: nowrap;
+	overflow: hidden;
 	max-width: 1px;
 }
-.hide-files-list a {
+.hide-files-row a {
 	margin-right: 1em;
+	display: inline-block;
 }
 
 /* Correct style and color for all links */
@@ -68,6 +70,6 @@
 }
 
 /* The magic */
-.hide-files-toggle:not(:checked) ~ .files .hide-files-row .hide-files-list {
+.hide-files-toggle:not(:checked) ~ .files .hide-files-row a {
 	display: none;
 }

--- a/source/hide-files-on-github.tsx
+++ b/source/hide-files-on-github.tsx
@@ -86,7 +86,7 @@ function addToggleBtn(previewList?: HTMLElement[]): void {
 	container.append(...previewList);
 
 	if (navigator.userAgent.includes('Firefox/')) {
-		// Due to https://github.com/sindresorhus/hide-files-on-github/issues/93
+		// Due to FOUC on Firefox #93
 		setTimeout(addEllipsis, 100, container, previewList);
 	} else {
 		addEllipsis(container, previewList);
@@ -96,20 +96,16 @@ function addToggleBtn(previewList?: HTMLElement[]): void {
 function addEllipsis(container: HTMLElement, previewList: HTMLElement[]): void {
 	const availableWidth = container.getBoundingClientRect().width;
 	if (availableWidth === container.scrollWidth) {
-		return; // No overflow
+		return; // No overflow = No ellipsis necessary
 	}
 
-	// Drop extra links on long lists
 	let ellipsis = false;
 	for (const file of previewList.slice(5)) {
-		// Remove extra files when the ellipsis is added
 		if (ellipsis) {
+			// Remove extra files when the ellipsis is added
 			file.remove();
-			continue;
-		}
-
-		// First first element in the unsafe/overflowing area
-		if (file.offsetLeft + file.offsetWidth > availableWidth - ellipsisWidth) {
+		} else if (file.offsetLeft + file.offsetWidth > availableWidth - ellipsisWidth) {
+			// We found the first element in the unsafe/overflowing area
 			container.append(<label for="HFT"><a>etc...</a></label>);
 			ellipsis = true;
 			file.remove();

--- a/source/hide-files-on-github.tsx
+++ b/source/hide-files-on-github.tsx
@@ -53,7 +53,7 @@ function updateUI(): void {
 	addToggleBtn(previewList);
 }
 
-async function addToggleBtn(previewList?: HTMLElement[]): Promise<void> {
+function addToggleBtn(previewList?: HTMLElement[]): void {
 	const btnRow = select('.hide-files-row')!;
 	const tbody = select('table.files tbody')!;
 	if (btnRow) {


### PR DESCRIPTION
Fixes #93 

For whatever reasons, the moment you call `getBoundingClientRect` or any `offset*` properties, we get that ugly FOUC. I'd been seeing this for a long time but never thought it could be an extension causing it.

---

In Firefox only, hide overflowing items _and then,_ after a short wait (🤷‍♂️) run the calculations. 

# Test

https://github.com/babel/babel